### PR TITLE
Remove warning when running bundle install.

### DIFF
--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -6,6 +6,6 @@ Gem::Specification.new do |s|
   s.summary = "Exception notification by email for Rails apps"
   s.email = "smartinez87@gmail.com"
 
-  s.files = ['README'] + Dir['lib/**/*']
+  s.files = ['README.md'] + Dir['lib/**/*']
   s.require_path = 'lib'
 end


### PR DESCRIPTION
I changed exception_notification.gemspec to refer to (the new) README.md, not (the old) README
