### PR TITLE
Use values set for the middleware as defaults

### DIFF
--- a/lib/exception_notifier.rb
+++ b/lib/exception_notifier.rb
@@ -12,13 +12,19 @@ class ExceptionNotifier
 
   def initialize(app, options = {})
     @app, @options = app, options
+    
+    Notifier.default_sender_address       = @options[:sender_address]
+    Notifier.default_exception_recipients = @options[:exception_recipients]
+    Notifier.default_email_prefix         = @options[:email_prefix]
+    Notifier.default_sections             = @options[:sections]
+    
     @options[:ignore_exceptions] ||= self.class.default_ignore_exceptions
   end
 
   def call(env)
     @app.call(env)
   rescue Exception => exception
-    options = (env['exception_notifier.options'] ||= {})
+    options = (env['exception_notifier.options'] ||= Notifier.default_options)
     options.reverse_merge!(@options)
 
     unless Array.wrap(options[:ignore_exceptions]).include?(exception.class)

--- a/lib/exception_notifier/notifier.rb
+++ b/lib/exception_notifier/notifier.rb
@@ -7,20 +7,25 @@ class ExceptionNotifier
     self.append_view_path "#{File.dirname(__FILE__)}/views"
 
     class << self
+      attr_writer :default_sender_address
+      attr_writer :default_exception_recipients
+      attr_writer :default_email_prefix
+      attr_writer :default_sections
+      
       def default_sender_address
-        %("Exception Notifier" <exception.notifier@default.com>)
+        @default_sender_address || %("Exception Notifier" <exception.notifier@default.com>)
       end
 
       def default_exception_recipients
-        []
+        @default_exception_recipients || []
       end
 
       def default_email_prefix
-        "[ERROR] "
+        @default_email_prefix || "[ERROR] "
       end
 
       def default_sections
-        %w(request session environment backtrace)
+        @default_sections || %w(request session environment backtrace)
       end
 
       def default_options


### PR DESCRIPTION
ExceptionNotifier works OK as long as you don't have to manually
call the `Notifier#exception_notification` method yourself and
rely on the middleware to do your job.

However, if you are using a Rails action to show 500 errors (e.g.
you are using the `rescue_from` helper in your
ApplicationController), then you will have to reconfigure the
ExceptionNotifier options.

This means that in your controller you'd have something like:

```
rescue_from Exception, :with => :server_error

def server_error(exception)
  request.env['exception_notifier.options'] = {
    :sender_address => "notifier@example.com",
    :exception_recipients => "dev@example.com"
  }

  ExceptionNotifier::Notifier.exception_notification(
    request.env, exception
  ).deliver
end
```

... which means code duplication, especially if you have more
than one action that's handling exceptions.

This commit should solve this problem by making the default
attributes writable and use the initial middleware configuration
to set those defaults to something more sensible.
