### PR TITLE
Added option to exclude exception.message from subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ run on production. You can make it work by
 
 Customization
 ---
-
+By default subject includes exception message. Use :verbose_subject => false
+to exclude it from subject.
 By default, the notification email includes four parts: request, session,
 environment, and backtrace (in that order). You can customize how each of those
 sections are rendered by placing a partial named for that part in your

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    exception_notification (2.4.1)
+    exception_notification (2.5.2)
       actionmailer (>= 3.0.4)
 
 GEM

--- a/test/dummy/test/functional/posts_controller_test.rb
+++ b/test/dummy/test/functional/posts_controller_test.rb
@@ -69,4 +69,18 @@ class PostsControllerTest < ActionController::TestCase
     assert request.ssl?
     assert @secured_mail.body.include? "* session id: [FILTERED]\n  *"
   end
+
+  test "should not include exception message in subject" do
+    begin
+      @post = posts(:one)
+      post :create, :post => @post.attributes
+    rescue => e
+      @exception = e
+      custom_env = request.env
+      custom_env['exception_notifier.options']||={}
+      custom_env['exception_notifier.options'].merge!(:verbose_subject => false)
+      @mail = ExceptionNotifier::Notifier.exception_notification(custom_env, @exception)
+    end
+    assert_equal "[Dummy ERROR] # (NoMethodError)", @mail.subject
+  end
 end


### PR DESCRIPTION
Allow to exclude exception.message from subject.
By default exception.message included in subject.
