### PR TITLE
Make sure exceptions in view template doesn't cause problems.

### DIFF
--- a/lib/exception_notifier/views/exception_notifier/exception_notification.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/exception_notification.text.erb
@@ -3,11 +3,19 @@ A <%= @exception.class %> occurred in <%= @kontroller.controller_name %>#<%= @ko
   <%= raw @exception.message %>
   <%= raw @backtrace.first %>
 
-<%  sections = @sections.map do |section|
+<%
+  begin
+    sections = @sections.map do |section|
       summary = render(section).strip
       unless summary.blank?
         title = render("title", :title => section).strip
         "#{title}\n\n#{summary.gsub(/^/, "  ")}\n\n"
       end
-    end %>
+    end
+
+  rescue Exception => e
+    sections = ["(ERROR: Failed to generate exception summary: %s)" % e.message]
+  end
+%>
+
 <%= raw sections.join %>


### PR DESCRIPTION
(Squashed version of #33).

If the exception originally was because of e.g. a character encoding
issue (or any other issue related to the request environment data, which
ExceptionNotifer uses in its output mail), then the same error will
surface when generating the output for the exception mail.

This patch rescues any such exceptions, allowing for the exception mail
to reach the developer anyway.
