### PR TITLE
Solaris issue with hostname -s 

### DIFF
--- a/lib/exception_notifier/views/exception_notifier/_environment.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/_environment.text.erb
@@ -5,4 +5,4 @@
 <% end -%>
 
 * Process: <%= raw $$ %>
-* Server : <%= raw `hostname -s`.chomp %>
+* Server : <%= raw `hostname`.chomp %>


### PR DESCRIPTION
Fix for: 
`Rendered /opt/ruby-enterprise/lib/ruby/gems/1.8/gems/exception_notification-2.4.1/lib/exception_notifier/views/exception_notifier/_request.text.erb (0.2ms)
Rendered /opt/ruby-enterprise/lib/ruby/gems/1.8/gems/exception_notification-2.4.1/lib/exception_notifier/views/exception_notifier/_title.text.erb (0.1ms)
Rendered /opt/ruby-enterprise/lib/ruby/gems/1.8/gems/exception_notification-2.4.1/lib/exception_notifier/views/exception_notifier/_session.text.erb (0.8ms)
Rendered /opt/ruby-enterprise/lib/ruby/gems/1.8/gems/exception_notification-2.4.1/lib/exception_notifier/views/exception_notifier/_title.text.erb (0.1ms)
Rendered /opt/ruby-enterprise/lib/ruby/gems/1.8/gems/exception_notification-2.4.1/lib/exception_notifier/views/exception_notifier/_environment.text.erb (2.5ms)
Rendered /opt/ruby-enterprise/lib/ruby/gems/1.8/gems/exception_notification-2.4.1/lib/exception_notifier/views/exception_notifier/exception_notification.text.erb (4.6ms)
Rendered /opt/ruby-enterprise/lib/ruby/gems/1.8/gems/exception_notification-2.4.1/lib/exception_notifier/views/exception_notifier/_request.text.erb (0.1ms)
Rendered /opt/ruby-enterprise/lib/ruby/gems/1.8/gems/exception_notification-2.4.1/lib/exception_notifier/views/exception_notifier/_title.text.erb (0.1ms)
Rendered /opt/ruby-enterprise/lib/ruby/gems/1.8/gems/exception_notification-2.4.1/lib/exception_notifier/views/exception_notifier/_session.text.erb (0.8ms)
Rendered /opt/ruby-enterprise/lib/ruby/gems/1.8/gems/exception_notification-2.4.1/lib/exception_notifier/views/exception_notifier/_title.text.erb (0.1ms)
Rendered /opt/ruby-enterprise/lib/ruby/gems/1.8/gems/exception_notification-2.4.1/lib/exception_notifier/views/exception_notifier/_environment.text.erb (2.5ms)
Rendered /opt/ruby-enterprise/lib/ruby/gems/1.8/gems/exception_notification-2.4.1/lib/exception_notifier/views/exception_notifier/exception_notification.text.erb (4.3ms)

ActionView::Template::Error (Not enough space - hostname -s):
    5: <% end -%>
    6: 
    7: \* Process: <%= raw $$ %>
    8: \* Server : <%= raw `hostname -s`.chomp %>
`

Using hostname without the -s fixes the problem
