### PR TITLE
option to remove numbers from email subjects so that they thread

### DIFF
--- a/lib/exception_notifier.rb
+++ b/lib/exception_notifier.rb
@@ -23,6 +23,7 @@ class ExceptionNotifier
     Notifier.default_sections             = @options[:sections]
     Notifier.default_background_sections  = @options[:background_sections]
     Notifier.default_verbose_subject      = @options[:verbose_subject]
+    Notifier.default_normalize_subject    = @options[:normalize_subject]
 
     @options[:ignore_exceptions] ||= self.class.default_ignore_exceptions
     @options[:ignore_crawlers]   ||= self.class.default_ignore_crawlers

--- a/lib/exception_notifier/notifier.rb
+++ b/lib/exception_notifier/notifier.rb
@@ -15,6 +15,7 @@ class ExceptionNotifier
       attr_writer :default_sections
       attr_writer :default_background_sections
       attr_writer :default_verbose_subject
+      attr_writer :default_normalize_subject
 
       def default_sender_address
         @default_sender_address || %("Exception Notifier" <exception.notifier@default.com>)
@@ -40,13 +41,22 @@ class ExceptionNotifier
         @default_verbose_subject.nil? || @default_verbose_subject
       end
 
+      def default_normalize_subject
+        @default_normalize_prefix || false
+      end
+
       def default_options
         { :sender_address => default_sender_address,
           :exception_recipients => default_exception_recipients,
           :email_prefix => default_email_prefix,
           :sections => default_sections,
           :background_sections => default_background_sections,
-          :verbose_subject => default_verbose_subject }
+          :verbose_subject => default_verbose_subject,
+          :normalize_subject => default_normalize_subject }
+      end
+
+      def normalize_digits(string)
+        string.gsub(/[0-9]+/, 'N')
       end
     end
 
@@ -103,6 +113,7 @@ class ExceptionNotifier
       subject << "#{kontroller.controller_name}##{kontroller.action_name}" if kontroller
       subject << " (#{exception.class})"
       subject << " #{exception.message.inspect}" if @options[:verbose_subject]
+      subject = normalize_digits(subject) if @options[:normalize_subject]
       subject.length > 120 ? subject[0...120] + "..." : subject
     end
 

--- a/test/exception_notification_test.rb
+++ b/test/exception_notification_test.rb
@@ -30,5 +30,10 @@ class ExceptionNotificationTest < ActiveSupport::TestCase
   test "should have ignored crawler by default" do
     assert ExceptionNotifier.default_ignore_crawlers == []
   end
+
+  test "should normalize multiple digits into one N" do
+    assert_equal 'N foo N bar N baz N',
+      ExceptionNotifier::Notifier.normalize_digits('1 foo 12 bar 123 baz 1234')
+  end
   
 end


### PR DESCRIPTION
This removes numbers from the subjects of emails, so that different instances of the same exception are more likely to be collected into the same thread by the email client.
