### PR TITLE
Fix for Issue #23 (unable to find custom sections)

### DIFF
--- a/lib/exception_notifier/notifier.rb
+++ b/lib/exception_notifier/notifier.rb
@@ -6,7 +6,6 @@ class ExceptionNotifier
     self.mailer_name = 'exception_notifier'
 
     #Append application view path to the ExceptionNotifier lookup context.
-    self.append_view_path Rails.root.nil? ? "app/views" : "#{Rails.root}/app/views/exception_notifier" if defined?(Rails)
     self.append_view_path "#{File.dirname(__FILE__)}/views"
 
     class << self
@@ -57,6 +56,8 @@ class ExceptionNotifier
     end
 
     def exception_notification(env, exception)
+      self.append_view_path Rails.root.nil? ? "app/views" : "#{Rails.root}/app/views" if defined?(Rails)
+      
       @env        = env
       @exception  = exception
       @options    = (env['exception_notifier.options'] || {}).reverse_merge(self.class.default_options)

--- a/test/dummy/app/views/exception_notifier/_new_section.text.erb
+++ b/test/dummy/app/views/exception_notifier/_new_section.text.erb
@@ -1,0 +1,1 @@
+* New section for testing

--- a/test/dummy/config/environment.rb
+++ b/test/dummy/config/environment.rb
@@ -4,7 +4,8 @@ require File.expand_path('../application', __FILE__)
 Dummy::Application.config.middleware.use ExceptionNotifier,
   :email_prefix => "[Dummy ERROR] ",
   :sender_address => %{"Dummy Notifier" <dummynotifier@example.com>},
-  :exception_recipients => %w{dummyexceptions@example.com}
+  :exception_recipients => %w{dummyexceptions@example.com},
+  :sections => ['new_section', 'request', 'session', 'environment', 'backtrace']
 
 # Initialize the rails application
 Dummy::Application.initialize!

--- a/test/dummy/test/functional/posts_controller_test.rb
+++ b/test/dummy/test/functional/posts_controller_test.rb
@@ -38,6 +38,10 @@ class PostsControllerTest < ActionController::TestCase
   test "mail should contain timestamp of exception in body" do
     assert @mail.body.include? "Timestamp : #{Time.now}"
   end
+  
+  test "mail should contain the newly defined section" do
+    assert @mail.body.include? "* New section for testing"
+  end
 
   test "should filter sensible data" do
     assert @mail.body.include? "secret\"=>\"[FILTERED]"

--- a/test/exception_notification_test.rb
+++ b/test/exception_notification_test.rb
@@ -14,7 +14,9 @@ class ExceptionNotificationTest < ActiveSupport::TestCase
   end
 
   test "should have default sections" do
-    assert ExceptionNotifier::Notifier.default_sections == %w(request session environment backtrace)
+    for section in %w(request session environment backtrace)
+      assert ExceptionNotifier::Notifier.default_sections.include? section
+    end
   end
 
   test "should have default background sections" do
@@ -28,4 +30,5 @@ class ExceptionNotificationTest < ActiveSupport::TestCase
   test "should have ignored crawler by default" do
     assert ExceptionNotifier.default_ignore_crawlers == []
   end
+  
 end


### PR DESCRIPTION
(This is my first pull request, so please be gentle with me!)

It looks like this was just an oversight, neglecting to put the exception_notifier directory at the end of the specification for the custom section path.

I have tested it in my application and it is working.

If you'd like me to write a test for this specifically, let me know.
