### PR TITLE
Output more information if exception mail itself generates exception.

### DIFF
--- a/lib/exception_notifier/views/exception_notifier/exception_notification.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/exception_notification.text.erb
@@ -4,18 +4,21 @@ A <%= @exception.class %> occurred in <%= @kontroller.controller_name %>#<%= @ko
   <%= raw @backtrace.first %>
 
 <%
-  begin
     sections = @sections.map do |section|
-      summary = render(section).strip
-      unless summary.blank?
+      begin
+        summary = render(section).strip
+        unless summary.blank?
+          title = render("title", :title => section).strip
+          "#{title}\n\n#{summary.gsub(/^/, "  ")}\n\n"
+        end
+
+      rescue Exception => e
         title = render("title", :title => section).strip
-        "#{title}\n\n#{summary.gsub(/^/, "  ")}\n\n"
+        summary = ["ERROR: Failed to generate exception summary:", [e.class.to_s, e.message].join(": "), e.backtrace && e.backtrace.join("\n")].compact.join("\n\n")
+
+        [title, summary.gsub(/^/, "  "), nil].join("\n\n")
       end
     end
-
-  rescue Exception => e
-    sections = ["(ERROR: Failed to generate exception summary: %s)" % e.message]
-  end
 %>
 
 <%= raw sections.join %>


### PR DESCRIPTION
By using a rescue block in each section (and outputting a backtrace) the
exception mail remains very informative despite failing to correctly
generate the exception mail.
