### PR TITLE
Allow overriding the email_prefix when manually creating a notification.

### DIFF
--- a/lib/exception_notifier/notifier.rb
+++ b/lib/exception_notifier/notifier.rb
@@ -71,6 +71,7 @@ class ExceptionNotifier
       @env        = env
       @exception  = exception
       @options    = (env['exception_notifier.options'] || {}).reverse_merge(self.class.default_options)
+      @options[:email_prefix] = options[:email_prefix] if options[:email_prefix].present?
       @kontroller = env['action_controller.instance'] || MissingController.new
       @request    = ActionDispatch::Request.new(env)
       @backtrace  = exception.backtrace ? clean_backtrace(exception) : []


### PR DESCRIPTION
A small feature that we like to separate different kinds of notifications.
