### PR TITLE
#95 Ignore exceptions with background_exception_notification

### DIFF
--- a/test/background_exception_notification_test.rb
+++ b/test/background_exception_notification_test.rb
@@ -71,9 +71,7 @@ class BackgroundExceptionNotificationTest < ActiveSupport::TestCase
       raise ActiveRecord::RecordNotFound
     rescue => e
       @ignored_exception = e
-      unless ExceptionNotifier.default_ignore_exceptions.include?(@ignored_exception.class.name)
-        @ignored_mail = ExceptionNotifier::Notifier.background_exception_notification(@ignored_exception)
-      end
+      @ignored_mail = ExceptionNotifier::BackgroundNotifier.exception_notification(@ignored_exception)
     end
 
     assert @ignored_exception.class.inspect == "ActiveRecord::RecordNotFound"

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -11,7 +11,6 @@ Dummy::Application.configure do
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
-  config.action_view.debug_rjs             = true
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -16,8 +17,8 @@ ActiveRecord::Schema.define(:version => 20110729022608) do
     t.string   "title"
     t.text     "body"
     t.string   "secret"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
   end
 
 end


### PR DESCRIPTION
When user configured exception_notification with ignored_exceptions, now only the
middleware will ignore such exceptions. The background delivery should also do that.
