### PR TITLE
Don't error if Rails isn't defined.

### DIFF
--- a/lib/exception_notifier/notifier.rb
+++ b/lib/exception_notifier/notifier.rb
@@ -132,7 +132,7 @@ class ExceptionNotifier
     end
 
     def clean_backtrace(exception)
-      if Rails.respond_to?(:backtrace_cleaner)
+      if defined?(Rails) and Rails.respond_to?(:backtrace_cleaner)
        Rails.backtrace_cleaner.send(:filter, exception.backtrace)
       else
        exception.backtrace


### PR DESCRIPTION
This was causing errors when Rails wasn't defined:
`Uninitialized constant NotifierException::Notifier::Rails`

The easiest fix seems to be to check that Rails is defined before trying to check if it responds to backtrace_cleaner.
