### PR TITLE
Adding :notifier_proc option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    exception_notification (3.0.1.rc1)
+    exception_notification (3.0.1)
       actionmailer (>= 3.0.4)
 
 GEM

--- a/lib/exception_notifier.rb
+++ b/lib/exception_notifier.rb
@@ -35,7 +35,7 @@ class ExceptionNotifier
     @options[:ignore_exceptions] ||= self.class.default_ignore_exceptions
     @options[:ignore_crawlers]   ||= self.class.default_ignore_crawlers
     @options[:ignore_if]         ||= lambda { |env, e| false }
-    @options[:notifier_proc]     ||= ->(env, exception) { Notifier.exception_notification(env, exception).deliver }
+    @options[:notifier_proc]     ||= lambda { |env, e| Notifier.exception_notification(env, e).deliver }
   end
 
   def call(env)

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    exception_notification (3.0.0)
+    exception_notification (3.0.1)
       actionmailer (>= 3.0.4)
 
 GEM

--- a/test/dummy/config/environment.rb
+++ b/test/dummy/config/environment.rb
@@ -7,7 +7,10 @@ Dummy::Application.config.middleware.use ExceptionNotifier,
   :exception_recipients => %w{dummyexceptions@example.com},
   :email_headers => { "X-Custom-Header" => "foobar" },
   :sections => ['new_section', 'request', 'session', 'environment', 'backtrace'],
-  :background_sections => %w(new_bkg_section) + ExceptionNotifier::Notifier.default_background_sections
+  :background_sections => %w(new_bkg_section) + ExceptionNotifier::Notifier.default_background_sections,
+  :notifier_proc => lambda { |env, e|
+    Notifier.exception_notification(env, e, data: {ciao: 'ola'}).deliver
+  }
 
 # Initialize the rails application
 Dummy::Application.initialize!

--- a/test/dummy/test/functional/posts_controller_test.rb
+++ b/test/dummy/test/functional/posts_controller_test.rb
@@ -64,7 +64,6 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   test "mail should contain the data added by the custom notifier_proc" do
-    puts @mail.encoded
     assert @mail.encoded.include? 'ciao'
   end
 

--- a/test/dummy/test/functional/posts_controller_test.rb
+++ b/test/dummy/test/functional/posts_controller_test.rb
@@ -63,6 +63,11 @@ class PostsControllerTest < ActionController::TestCase
     assert @mail.encoded.include? 'X-Custom-Header: foobar'
   end
 
+  test "mail should contain the data added by the custom notifier_proc" do
+    puts @mail.encoded
+    assert @mail.encoded.include? 'ciao'
+  end
+
   test "mail should not contain any attachments" do
     assert @mail.attachments == []
   end


### PR DESCRIPTION
Hello,

I have the needing to customize the notifier processing (I manage the email sending using DelayedJob), so I added a `notifier_proc` option, which I use it in this way:

```ruby
module EasyMarshalDumpableHash
  def self.easy_marshal_dumpable_hash(hash)
    Hash[ hash.map do |k, v|
      [ k,
        if v.is_a?(Hash)
          easy_marshal_dumpable_hash(v)
        else
          begin
            Marshal.dump(v)
            v
          rescue TypeError
            v.inspect
          end
        end ]
    end ]
  end
end

class ControllerInfo
  attr_reader :controller_name, :action_name

  def initialize(controller_name, action_name)
    @controller_name, @action_name = controller_name, action_name
  end
end

Desy::Application.configure do
  # ExceptionNotifier configuration
  config.middleware.use ExceptionNotifier,
                        notifier_proc:        ->(env, exception) do
                          md_env = EasyMarshalDumpableHash.easy_marshal_dumpable_hash(env)
                          md_env['action_controller.instance'] = ControllerInfo.new(env['action_controller.instance'].controller_name, env['action_controller.instance'].action_name)

                          Delayed::Job.enqueue ExceptionNotifierJob.new(md_env, exception)
                        end
end
```

(The part before the configuration is not interesting, I added it just to make a working example).

Maybe this feature could be useful to other people, since it makes the sending management more flexible.

Feel free to tell me to fix some code (style, test, docs...) or do it yourself at your pleasure.