### PR TITLE
Allow JRuby to run tests 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source "https://rubygems.org"
 
 gemspec
+
+# Platform dependent gems for development
+gem "sqlite3", ">= 1.3.4", platform: :ruby
+gem "jdbc-sqlite3", ">= 3.7.2",  platform: :jruby
+gem "activerecord-jdbc-adapter", ">= 1.2.8",  platform: :jruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
       activesupport (= 3.2.6)
       arel (~> 3.0.2)
       tzinfo (~> 0.3.29)
+    activerecord-jdbc-adapter (1.2.9)
     activeresource (3.2.6)
       activemodel (= 3.2.6)
       activesupport (= 3.2.6)
@@ -49,6 +50,7 @@ GEM
       thor
     erubis (2.7.0)
     eventmachine (1.0.3)
+    eventmachine (1.0.3-java)
     faraday (0.8.7)
       multipart-post (~> 1.1)
     faraday_middleware (0.9.0)
@@ -56,12 +58,15 @@ GEM
     hashie (1.2.0)
     hike (1.2.1)
     http_parser.rb (0.5.3)
+    http_parser.rb (0.5.3-java)
     httparty (0.10.2)
       multi_json (~> 1.0)
       multi_xml (>= 0.5.2)
     i18n (0.6.0)
+    jdbc-sqlite3 (3.7.2.1)
     journey (1.0.4)
     json (1.7.3)
+    json (1.7.3-java)
     mail (2.4.4)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
@@ -133,13 +138,16 @@ GEM
     tzinfo (0.3.33)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES
+  activerecord-jdbc-adapter (>= 1.2.8)
   appraisal
   coveralls (~> 0.6.5)
   exception_notification!
   httparty (~> 0.10.2)
+  jdbc-sqlite3 (>= 3.7.2)
   mocha (>= 0.13.0)
   rails (>= 3.0.4)
   sqlite3 (>= 1.3.4)

--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "tinder", "~> 1.8"
   s.add_development_dependency "httparty", "~> 0.10.2"
   s.add_development_dependency "mocha", ">= 0.13.0"
-  s.add_development_dependency "sqlite3", ">= 1.3.4"
   s.add_development_dependency "coveralls", "~> 0.6.5"
   s.add_development_dependency "appraisal", ">= 0"
 end

--- a/test/dummy/Gemfile
+++ b/test/dummy/Gemfile
@@ -5,7 +5,10 @@ gem 'rails', '3.2.8'
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'
 
-gem 'sqlite3'
+
+gem "sqlite3", ">= 1.3.4", platform: :ruby
+gem "jdbc-sqlite3", ">= 3.7.2",  platform: :jruby
+gem "activerecord-jdbc-adapter", ">= 1.2.8",  platform: :jruby
 
 gem 'tinder'
 gem 'httparty'

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
       activesupport (= 3.2.8)
       arel (~> 3.0.2)
       tzinfo (~> 0.3.29)
+    activerecord-jdbc-adapter (1.2.9)
     activeresource (3.2.8)
       activemodel (= 3.2.8)
       activesupport (= 3.2.8)
@@ -39,6 +40,7 @@ GEM
     builder (3.0.4)
     erubis (2.7.0)
     eventmachine (1.0.3)
+    eventmachine (1.0.3-java)
     faraday (0.8.7)
       multipart-post (~> 1.1)
     faraday_middleware (0.9.0)
@@ -46,12 +48,15 @@ GEM
     hashie (1.2.0)
     hike (1.2.2)
     http_parser.rb (0.5.3)
+    http_parser.rb (0.5.3-java)
     httparty (0.10.2)
       multi_json (~> 1.0)
       multi_xml (>= 0.5.2)
     i18n (0.6.4)
+    jdbc-sqlite3 (3.7.2.1)
     journey (1.0.4)
     json (1.7.5)
+    json (1.7.5-java)
     mail (2.4.4)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
@@ -114,11 +119,14 @@ GEM
     tzinfo (0.3.37)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES
+  activerecord-jdbc-adapter (>= 1.2.8)
   exception_notification!
   httparty
+  jdbc-sqlite3 (>= 3.7.2)
   rails (= 3.2.8)
-  sqlite3
+  sqlite3 (>= 1.3.4)
   tinder


### PR DESCRIPTION
In an attempt to track down the `ActionView::Template::Error (Illegal replacement)` transcoding error in JRuby, I updated sqlite gem to be platform specific:

    gem "sqlite3", ">= 1.3.4", platform: :ruby
    gem "jdbc-sqlite3", ">= 3.7.2",  platform: :jruby
    gem "activerecord-jdbc-adapter", ">= 1.2.8",  platform: :jruby

 The one caveat for this to work is these gems have to be moved to the Gemfile and out of the gemspec. 

Issue #156