### PR TITLE
Check for sane options in email_notifier

### DIFF
--- a/lib/exception_notifier/email_notifier.rb
+++ b/lib/exception_notifier/email_notifier.rb
@@ -20,6 +20,7 @@ module ExceptionNotifier
           self.append_view_path "#{File.dirname(__FILE__)}/views"
 
           def exception_notification(env, exception, options={}, default_options={})
+            check_for_sane_options(options)
             load_custom_views
 
             @env        = env
@@ -36,6 +37,7 @@ module ExceptionNotifier
           end
 
           def background_exception_notification(exception, options={}, default_options={})
+            check_for_sane_options(options)
             load_custom_views
 
             @exception = exception
@@ -48,6 +50,17 @@ module ExceptionNotifier
           end
 
           private
+
+          def check_for_sane_options(options)
+            check_for_sane_data_option(options[:data]) if options[:data].present?
+          end
+
+          def check_for_sane_data_option(data_option)
+            reserved_keys = %w(env exception options kontroller request backtrace sections data)
+            data_option.keys.each do |key|
+              raise "Reserved key '#{key}' used in data option. Please do not use #{reserved_keys.join(",")} as keys." if reserved_keys.include? key.to_s
+            end
+          end
 
           def compose_subject
             subject = "#{@options[:email_prefix]}"


### PR DESCRIPTION
Because #set_data_variables will create instance variables for
each key found in options[:data], check to make sure key names are
sane and will not interfer with functioning of EmailNotifier.
