### PR TITLE
Added more values to exception hash in webhook call method

### DIFF
--- a/lib/exception_notifier/webhook_notifier.rb
+++ b/lib/exception_notifier/webhook_notifier.rb
@@ -27,11 +27,11 @@ module ExceptionNotifier
       options[:body] ||= {}
       options[:body][:exception] = {:error_class => exception.class.to_s,
                                     :message => exception.message.inspect,
-                                    :backtrace => exception.backtrace,
-                                    :data => (env['exception_notifier.exception_data'] || {}).merge(options[:data] || {}),
-                                    :request => (request_items || {})
-                                  }
-
+                                    :backtrace => exception.backtrace}
+      
+      options[:body][:request] = (request_items || {})
+      options[:body][:data] = (env['exception_notifier.exception_data'] || {}).merge(options[:data] || {})
+      
       HTTParty.send(http_method, url, options)
     end
   end

--- a/test/exception_notifier/webhook_notifier_test.rb
+++ b/test/exception_notifier/webhook_notifier_test.rb
@@ -15,14 +15,14 @@ class WebhookNotifierTest < ActiveSupport::TestCase
     assert response[:body][:exception][:message].include? "divided by 0"
     assert response[:body][:exception][:backtrace].include? "/exception_notification/test/webhook_notifier_test.rb:48"
     
-    assert response[:body][:exception][:cookies].has_key?(:cookie_item1)
-    assert_equal response[:body][:exception][:url], "http://example.com/example"
-    assert_equal response[:body][:exception][:ip_address], "192.168.1.1"
-    assert response[:body][:exception][:environment].has_key?(:env_item1)
-    assert_equal response[:body][:exception][:controller], "#<ControllerName:0x007f9642a04d00>"
-    assert response[:body][:exception][:session].has_key?(:session_item1)
-    assert response[:body][:exception][:parameters].has_key?(:controller)
-    assert response[:body][:exception][:data].has_key?(:data_item1)
+    assert response[:body][:request][:cookies].has_key?(:cookie_item1)
+    assert_equal response[:body][:request][:url], "http://example.com/example"
+    assert_equal response[:body][:request][:ip_address], "192.168.1.1"
+    assert response[:body][:request][:environment].has_key?(:env_item1)
+    assert_equal response[:body][:request][:controller], "#<ControllerName:0x007f9642a04d00>"
+    assert response[:body][:request][:session].has_key?(:session_item1)
+    assert response[:body][:request][:parameters].has_key?(:controller)
+    assert response[:body][:data][:extra_data].has_key?(:data_item1)
   end
 
   private
@@ -34,15 +34,19 @@ class WebhookNotifierTest < ActiveSupport::TestCase
         :exception => {
           :error_class => 'ZeroDivisionError',
           :message => 'divided by 0',
-          :backtrace => '/exception_notification/test/webhook_notifier_test.rb:48:in `/',
+          :backtrace => '/exception_notification/test/webhook_notifier_test.rb:48:in `/'
+        },
+        :data => {
+          :extra_data => {:data_item1 => "datavalue1", :data_item2 => "datavalue2"}
+        },
+        :request => {
           :cookies => {:cookie_item1 => 'cookieitemvalue1', :cookie_item2 => 'cookieitemvalue2'},
           :url => 'http://example.com/example',
           :ip_address => '192.168.1.1',
           :environment => {:env_item1 => "envitem1", :env_item2 => "envitem2"},
           :controller => '#<ControllerName:0x007f9642a04d00>',
           :session => {:session_item1 => "sessionitem1", :session_item2 => "sessionitem2"},
-          :parameters => {:action =>"index", :controller =>"projects"},
-          :data => {:data_item1 => "datavalue1", :data_item2 => "datavalue2"}
+          :parameters => {:action =>"index", :controller =>"projects"}
         }
       }
     }


### PR DESCRIPTION
I've added more data to the body when sending a notification to the webhook URL.
