### PR TITLE
gracefully handle missing coveralls gem

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,12 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require "coveralls"
-Coveralls.wear!
+begin
+  require "coveralls"
+  Coveralls.wear!
+rescue LoadError
+  warn "warning: coveralls gem not found; skipping Coveralls"
+end
 
 require File.expand_path("../dummy/config/environment.rb", __FILE__)
 require "rails/test_help"


### PR DESCRIPTION
If we do not have coveralls installed, we should be able to continue with the rest of the test suite.
