### PR TITLE
load attribute_accessors for ActiveSupport 4

### DIFF
--- a/lib/exception_notifier.rb
+++ b/lib/exception_notifier.rb
@@ -1,5 +1,6 @@
 require 'logger'
 require 'active_support/core_ext/string/inflections'
+require 'active_support/core_ext/module/attribute_accessors'
 
 module ExceptionNotifier
 


### PR DESCRIPTION
When using ActiveSupport 4, we must explicitly load attribute_accessors in order to use the mattr_accessor function in ExceptionNotifier.

Tested with ActiveSupport 3.2.13 and 4.0.0.

(Note that we only hit this bug when using ExceptionNotifier outside of Bundler, since Gemfile.lock is presently locking activesupport to 3.2. I assume that activesupport in exception_notification's Gemfile.lock will be updated at some point in the future, at which point this will become relevant to Bundler users as well.)
