### PR TITLE
Explicitly convert session to hash

### DIFF
--- a/lib/exception_notifier/views/exception_notifier/_session.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/_session.html.erb
@@ -5,6 +5,6 @@
   </li>
   <li>
     <strong>data: </strong>
-    <span><%= raw PP.pp(@request.session, "") %></span>
+    <span><%= raw PP.pp(@request.session.to_hash, "") %></span>
   </li>
 </ul>

--- a/lib/exception_notifier/views/exception_notifier/_session.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/_session.text.erb
@@ -1,2 +1,2 @@
 * session id: <%= @request.ssl? ? "[FILTERED]" : (raw (@request.session['session_id'] || (@request.env["rack.session.options"] and @request.env["rack.session.options"][:id])).inspect.html_safe) %>
-* data: <%= raw PP.pp(@request.session, "") %>
+* data: <%= raw PP.pp(@request.session.to_hash, "") %>


### PR DESCRIPTION
In Rails 4.0, `@request.session` is an `ActionDispatch::Request::Session` object now (whereas in 3.x it was an `Rack::Session::Abstract::SessionHash` object).

It seems that calling `PP.pp(@request.session, "")` in Rails 4.0 now outputs something like this:

```
#<ActionDispatch::Request::Session:0x007f663c5f6438 ...>
```

Instead of the following (which is what Rails 3.x output):

```
{"session_id"=>"c358e974d2640f3100ae83f7f8a50020", "user_id"=>5}
```

Explicitly converting the `@request.session` object to a hash appears to work both in 3.x and 4.x. Unfortunately, I couldn't find a way to write a test for this, as Rails' test framework uses an `ActionController:TestSession` object to manage sessions, which doesn't exhibit the same issue that the new `ActionDispatch::Request::Session` object does. If anyone has some input on how to properly test this, let me know.
