### PR TITLE
ignore dot files in the gemspec file list

### DIFF
--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.8.11'
 
   s.files = `git ls-files`.split("\n")
+  s.files -= `git ls-files -- .??*`.split("\n")
   s.test_files = `git ls-files -- test`.split("\n")
   s.require_path = 'lib'
 


### PR DESCRIPTION
The dot files `.gemtest`, `.gitignore`, and `.travis.yml` are automatically included in the main "`git ls-files`" command, but we don't need to ship these to the to users of the gem. It's better to exclude these dot files from the gem packaging altogether. This allows for slimmer gem packages as well as simpler RPM packaging.
