### PR TITLE
Add message_template option to HipChat notifier

### DIFF
--- a/test/exception_notifier/hipchat_notifier_test.rb
+++ b/test/exception_notifier/hipchat_notifier_test.rb
@@ -59,6 +59,20 @@ class HipchatNotifierTest < ActiveSupport::TestCase
     assert_nil hipchat.room
   end
 
+  test "should send hipchat notification with message_template" do
+    options = {
+      :api_token => 'good_token',
+      :room_name => 'room_name',
+      :color     => 'yellow',
+      :message_template => ->(exception) { "This is custom message: '#{exception.message}'" }
+    }
+
+    HipChat::Room.any_instance.expects(:send).with('Exception', "This is custom message: '#{fake_exception.message}'", { :color => 'yellow' })
+
+    hipchat = ExceptionNotifier::HipchatNotifier.new(options)
+    hipchat.call(fake_exception)
+  end
+
   private
 
   def fake_body


### PR DESCRIPTION
In this pull req I add `message_template` option for HipChat notifier.
It allows users to customize messages from the notifier.

---

`message_template` option must be Proc with exception as an argument.

Example:

``` ruby
Whatever::Application.config.middleware.use ExceptionNotification::Rack,
  :hipchat => {
    :api_token => 'my_token',
    :room_name => 'my_room',
    :message_template => ->(exception) { "Exception: #{exception.class}: #{exception.message} on #{exception.backtrace[0..3].join("\n")}" },
  }
```
