### PR TITLE
Allow HipChat API version to be specified.

### DIFF
--- a/lib/exception_notifier/hipchat_notifier.rb
+++ b/lib/exception_notifier/hipchat_notifier.rb
@@ -9,8 +9,9 @@ module ExceptionNotifier
       begin
         api_token				  = options.delete(:api_token)
         room_name 			  = options.delete(:room_name)
+        api_version = options.delete(:api_version) || 'v1'
         @from             = options.delete(:from) || 'Exception'
-        @room     			  = HipChat::Client.new(api_token)[room_name]
+        @room     			  = hipchat_client(api_token, api_version)[room_name]
         @message_options  = options
         @message_options[:color] ||= 'red'
       rescue
@@ -30,5 +31,14 @@ module ExceptionNotifier
     def active?
       !@room.nil?
     end
+
+    def hipchat_client(api_token, api_version)
+      if api_version.eql?('v2')
+        HipChat::Client.new(api_token, :api_version => api_version)
+      else
+        HipChat::Client.new(api_token)
+      end
+    end
+
   end
 end

--- a/test/exception_notifier/hipchat_notifier_test.rb
+++ b/test/exception_notifier/hipchat_notifier_test.rb
@@ -59,6 +59,19 @@ class HipchatNotifierTest < ActiveSupport::TestCase
     assert_nil hipchat.room
   end
 
+  test "should allow API version to be specified" do
+    options = {
+      :api_token   => 'good_token',
+      :room_name   => 'room_name',
+      :color       => 'yellow',
+      :api_version => 'v1',
+    }
+    HipChat::Room.any_instance.expects(:send).with('Exception', fake_body, { :color => 'yellow' })
+
+    hipchat = ExceptionNotifier::HipchatNotifier.new(options)
+    hipchat.call(fake_exception)
+  end
+
   private
 
   def fake_body


### PR DESCRIPTION
This only works for newer versions of that HipChat gem. Therefore, we need to be backwards compatible AND default to HipChat's default (version 1).