### PR TITLE
Add IRC notifier, update README and tests accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,104 @@ Whatever::Application.config.middleware.use ExceptionNotification::Rack,
 
 For more HTTParty options, check out the [documentation](https://github.com/jnunemaker/httparty).
 
+### IRC notifier
+
+This notifier sends notifications to an IRC channel using the carrier-pigeon gem.
+
+#### Usage
+
+Just add the [carrier-pigeon](https://github.com/portertech/carrier-pigeon) gem to your `Gemfile`:
+
+```ruby
+gem 'carrier-pigeon'
+```
+
+To configure it, you need to set at least the 'domain' option, like this:
+
+```ruby
+Whatever::Application.config.middleware.use ExceptionNotification::Rack,
+  :email => {
+    :email_prefix => "[Whatever] ",
+    :sender_address => %{"notifier" <notifier@example.com>},
+    :exception_recipients => %w{exceptions@example.com}
+  },
+  :irc => {
+    :domain => 'irc.example.com'
+  }
+```
+
+There are several other options, which are described below. For example, to use ssl and a password, add a prefix, post to the '#log' channel, and include recipients in the message (so that they will be notified), your configuration might look like this:
+
+```ruby
+Whatever::Application.config.middleware.use ExceptionNotification::Rack,
+  :irc => {
+    :domain => 'irc.example.com',
+    :nick => 'BadNewsBot',
+    :password => 'secret',
+    :port => 6697,
+    :channel => '#log',
+    :ssl => true,
+    :prefix => '[Exception Notification]',
+    :recipients => ['peter', 'michael', 'samir']
+  }
+
+```
+
+#### Options
+
+##### domain
+
+*String, required*
+
+The domain name of your IRC server.
+
+##### nick
+
+*String, optional*
+
+The message will appear from this nick. Default : 'ExceptionNotifierBot'.
+
+##### password
+
+*String, optional*
+
+Password for your IRC server.
+
+##### port
+
+*String, optional*
+
+Port your IRC server is listening on. Default : 6667.
+
+##### channel
+
+*String, optional*
+
+Message will appear in this channel. Default : '#log'.
+
+##### notice
+
+*Boolean, optional*
+
+Send a notice. Default : false.
+
+##### ssl
+
+*Boolean, optional*
+
+Whether to use SSL. Default : false.
+
+##### join
+
+*Boolean, optional*
+
+Join a channel. Default : false.
+
+##### recipients
+
+*Array of strings, optional*
+
+Nicks to include in the message. Default: []
 
 ### Custom notifier
 

--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "coveralls", "~> 0.6.5"
   s.add_development_dependency "appraisal", ">= 0"
   s.add_development_dependency "hipchat", ">= 0.11.0"
+  s.add_development_dependency "carrier-pigeon", ">= 0.7.0"
 end

--- a/lib/exception_notifier.rb
+++ b/lib/exception_notifier.rb
@@ -9,6 +9,7 @@ module ExceptionNotifier
   autoload :CampfireNotifier, 'exception_notifier/campfire_notifier'
   autoload :HipchatNotifier, 'exception_notifier/hipchat_notifier'
   autoload :WebhookNotifier, 'exception_notifier/webhook_notifier'
+  autoload :IrcNotifier, 'exception_notifier/irc_notifier'
 
   class UndefinedNotifierError < StandardError; end
 

--- a/lib/exception_notifier/irc_notifier.rb
+++ b/lib/exception_notifier/irc_notifier.rb
@@ -1,0 +1,45 @@
+module ExceptionNotifier
+  class IrcNotifier
+    def initialize(options)
+      @config = OpenStruct.new
+      parse_options(options)
+    end
+
+    def call(exception, options={})
+      message = "'#{exception.message}' on '#{exception.backtrace.first}'"
+      send_message([*@config.prefix, *message].join(' ')) if active?
+    end
+
+    def send_message(message)
+      CarrierPigeon.send @config.irc.merge({message: message})
+    end
+
+    private
+      def parse_options(options)
+        nick = options.fetch(:nick, 'ExceptionNotifierBot')
+        password = options[:password] ? ":#{options[:password]}" : nil
+        domain = options.fetch(:domain, nil)
+        port = options[:port] ? ":#{options[:port]}" : nil
+        channel = options.fetch(:channel, '#log')
+        notice = options.fetch(:notice, false)
+        ssl = options.fetch(:ssl, false)
+        join = options.fetch(:join, false)
+        uri = "irc://#{nick}#{password}@#{domain}#{port}/#{channel}"
+        prefix = options.fetch(:prefix, nil)
+        recipients = options[:recipients] ? options[:recipients].join(', ') + ':' : nil
+
+        @config.prefix = [*prefix, *recipients].join(' ')
+        @config.irc = { uri: uri, ssl: ssl, notice: notice, join: join }
+      end
+
+      def active?
+        valid_uri? @config.irc[:uri]
+      end
+
+      def valid_uri?(uri)
+        !!URI.parse(uri)
+      rescue URI::InvalidURIError
+        false
+      end
+  end
+end

--- a/test/exception_notifier/irc_notifier_test.rb
+++ b/test/exception_notifier/irc_notifier_test.rb
@@ -1,0 +1,85 @@
+require 'test_helper'
+require 'carrier-pigeon'
+
+class IrcNotifierTest < ActiveSupport::TestCase
+
+  test "should send irc notification if properly configured" do
+    options = {
+      :domain => 'irc.example.com'
+    }
+
+    CarrierPigeon.expects(:send).with(has_key(:uri)) do |v|
+      /divided by 0/.match(v[:message])
+    end
+
+    irc = ExceptionNotifier::IrcNotifier.new(options)
+    irc.call(fake_exception)
+  end
+
+  test "should properly construct URI from constituent parts" do
+    options = {
+      :nick => 'BadNewsBot',
+      :password => 'secret',
+      :domain => 'irc.example.com',
+      :port => 9999,
+      :channel => '#exceptions'
+    }
+
+    CarrierPigeon.expects(:send).with(has_entry(uri: "irc://BadNewsBot:secret@irc.example.com:9999/#exceptions"))
+
+    irc = ExceptionNotifier::IrcNotifier.new(options)
+    irc.call(fake_exception)
+  end
+
+  test "should properly add recipients if specified" do
+    options = {
+      domain: 'irc.example.com',
+      recipients: ['peter', 'michael', 'samir']
+    }
+
+    CarrierPigeon.expects(:send).with(has_key(:uri)) do |v|
+      /peter, michael, samir/.match(v[:message])
+    end
+
+    irc = ExceptionNotifier::IrcNotifier.new(options)
+    irc.call(fake_exception)
+  end
+
+  test "should properly set miscellaneous options" do
+    options = {
+      domain: 'irc.example.com',
+      ssl: true,
+      join: true,
+      notice: true,
+      prefix: '[test notification]'
+    }
+
+    CarrierPigeon.expects(:send).with(has_entries(
+      ssl: true,
+      join: true,
+      notice: true,
+    )) do |v|
+      /\[test notification\]/.match(v[:message])
+    end
+
+    irc = ExceptionNotifier::IrcNotifier.new(options)
+    irc.call(fake_exception)
+  end
+
+  test "should not send irc notification if badly configured" do
+    wrong_params = { domain: '##scriptkiddie.com###'}
+    irc = ExceptionNotifier::IrcNotifier.new(wrong_params)
+
+    assert_nil irc.call(fake_exception)
+  end
+
+  private
+
+  def fake_exception
+    exception = begin
+      5/0
+    rescue Exception => e
+      e
+    end
+  end
+end


### PR DESCRIPTION
First of all, thanks for a great gem! We use it often and have never had issues.

We have a company IRC server, so I wanted to be able to send exception messages there. I'm not sure if this is within the scope of the project. If it's not, no big deal; we'll stick to our fork.

The notifier sends messages to an IRC channel using carrier pigeon. It can be configured with several options, which are explained in the README.

Thanks!
