### PR TITLE
Properly escape HTML based templates.

### DIFF
--- a/lib/exception_notifier/views/exception_notifier/_backtrace.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/_backtrace.html.erb
@@ -1,3 +1,3 @@
 <pre style="font-size: 12px; padding: 10px; border: 1px solid #e1e1e8; background-color:#f5f5f5">
-  <%= raw @backtrace.join("\n") %>
+<%= @backtrace.join("\n") %>
 </pre>

--- a/lib/exception_notifier/views/exception_notifier/_data.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/_data.html.erb
@@ -1,6 +1,6 @@
 <ul style="list-style: none">
   <li>
     <strong>data:</strong>
-    <span><%= raw PP.pp(@data, "") %></span>
+    <span><%= PP.pp(@data, "") %></span>
   </li>
 </ul>

--- a/lib/exception_notifier/views/exception_notifier/_request.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/_request.html.erb
@@ -1,36 +1,36 @@
 <ul style="list-style: none">
   <li>
     <strong>URL:</strong>
-    <span><%= raw @request.url %></span>
+    <span><%= @request.url %></span>
   </li>
   <li>
     <strong>HTTP Method:</strong>
-    <span><%= raw @request.request_method %></span>
+    <span><%= @request.request_method %></span>
   </li>
   <li>
     <strong>IP Address:</strong>
-    <span><%= raw @request.remote_ip %></span>
+    <span><%= @request.remote_ip %></span>
   </li>
   <li>
     <strong>Parameters:</strong>
-    <span><%= raw @request.filtered_parameters.inspect %></span>
+    <span><%= @request.filtered_parameters.inspect %></span>
   </li>
   <li>
     <strong>Timestamp:</strong>
-    <span><%= raw Time.current %></span>
+    <span><%= Time.current %></span>
   </li>
   <li>
     <strong>Server:</strong>
-    <span><%= raw Socket.gethostname %></span>
+    <span><%= Socket.gethostname %></span>
   </li>
   <% if defined?(Rails) %>
     <li>
       <strong>Rails root:</strong>
-      <span><%= raw Rails.root %></span>
+      <span><%= Rails.root %></span>
     </li>
   <% end %>
   <li>
     <strong>Process:</strong>
-    <span><%= raw $$ %></span>
+    <span><%= $$ %></span>
   </li>
 </ul>

--- a/lib/exception_notifier/views/exception_notifier/_session.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/_session.html.erb
@@ -1,10 +1,10 @@
 <ul style="list-style: none">
   <li>
     <strong>session_id: </strong>
-    <span><%= @request.ssl? ? "[FILTERED]" : (raw (@request.session['session_id'] || (@request.env["rack.session.options"] and @request.env["rack.session.options"][:id])).inspect.html_safe) %></span>
+    <span><%= @request.ssl? ? "[FILTERED]" : (@request.session['session_id'] || (@request.env["rack.session.options"] and @request.env["rack.session.options"][:id]).inspect) %></span>
   </li>
   <li>
     <strong>data: </strong>
-    <span><%= raw PP.pp(@request.session.to_hash, "") %></span>
+    <span><%= PP.pp(@request.session.to_hash, "") %></span>
   </li>
 </ul>

--- a/lib/exception_notifier/views/exception_notifier/_title.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/_title.html.erb
@@ -1,3 +1,3 @@
 <h2>
-  <%= raw title.to_s.humanize %>
+  <%= title.to_s.humanize %>
 </h2>

--- a/lib/exception_notifier/views/exception_notifier/background_exception_notification.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/background_exception_notification.html.erb
@@ -30,11 +30,11 @@
       <tr>
         <td style="padding: 10px; border: 1px solid #eed3d7; background-color: #f2dede">
           <h3 style="color: #b94a48">
-            <%= @exception.class.to_s =~ /^[aeiou]/i ? 'An' : 'A' %> <%= @exception.class %> occurred in background at <%= raw Time.current %> :
+            <%= @exception.class.to_s =~ /^[aeiou]/i ? 'An' : 'A' %> <%= @exception.class %> occurred in background at <%= Time.current %> :
           </h3>
-          <p style="color: #b94a48"><%= raw @exception.message %></p>
+          <p style="color: #b94a48"><%= @exception.message %></p>
           <pre style="font-size: 12px; padding: 5px; background-color:#f5f5f5">
-            <%= raw @backtrace.first %>
+<%= @backtrace.first %>
           </pre>
         </td>
       </tr>

--- a/lib/exception_notifier/views/exception_notifier/exception_notification.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/exception_notification.html.erb
@@ -32,9 +32,9 @@
           <h3 style="color: #b94a48">
             <%= @exception.class.to_s =~ /^[aeiou]/i ? 'An' : 'A' %> <%= @exception.class %> occurred in <%= @kontroller.controller_name %>#<%= @kontroller.action_name %>:
           </h3>
-          <p style="color: #b94a48"><%= raw @exception.message %></p>
+          <p style="color: #b94a48"><%= @exception.message %></p>
           <pre style="font-size: 12px; padding: 5px; background-color:#f5f5f5">
-            <%= raw @backtrace.first %>
+<%= @backtrace.first %>
           </pre>
         </td>
       </tr>


### PR DESCRIPTION
Properly HTML-escape everything in the HTML templates. Also remove leading spaces from `<pre>` elements.
