### PR TITLE
Check that Rails responds to root

### DIFF
--- a/lib/exception_notifier/email_notifier.rb
+++ b/lib/exception_notifier/email_notifier.rb
@@ -111,7 +111,9 @@ module ExceptionNotifier
           end
 
           def load_custom_views
-            self.prepend_view_path Rails.root.nil? ? "app/views" : "#{Rails.root}/app/views" if defined?(Rails)
+            if defined?(Rails) && Rails.respond_to?(:root)
+              self.prepend_view_path Rails.root.nil? ? "app/views" : "#{Rails.root}/app/views"
+            end
           end
         end
       end

--- a/lib/exception_notifier/views/exception_notifier/_request.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/_request.html.erb
@@ -23,7 +23,7 @@
     <strong>Server:</strong>
     <span><%= Socket.gethostname %></span>
   </li>
-  <% if defined?(Rails) %>
+  <% if defined?(Rails) && Rails.respond_to?(:root) %>
     <li>
       <strong>Rails root:</strong>
       <span><%= Rails.root %></span>

--- a/lib/exception_notifier/views/exception_notifier/_request.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/_request.text.erb
@@ -4,7 +4,7 @@
 * Parameters : <%= raw @request.filtered_parameters.inspect %>
 * Timestamp  : <%= raw Time.current %>
 * Server : <%= raw Socket.gethostname %>
-<% if defined?(Rails) %>
+<% if defined?(Rails) && Rails.respond_to?(:root) %>
 * Rails root : <%= raw Rails.root %>
 <% end %>
 * Process: <%= raw $$ %>

--- a/lib/exception_notifier/webhook_notifier.rb
+++ b/lib/exception_notifier/webhook_notifier.rb
@@ -17,7 +17,9 @@ module ExceptionNotifier
       options[:body] ||= {}
       options[:body][:server] = Socket.gethostname
       options[:body][:process] = $$
-      options[:body][:rails_root] = Rails.root if defined?(Rails)
+      if defined?(Rails) && Rails.respond_to?(:root)
+        options[:body][:rails_root] = Rails.root
+      end
       options[:body][:exception] = {:error_class => exception.class.to_s,
                                     :message => exception.message.inspect,
                                     :backtrace => exception.backtrace}


### PR DESCRIPTION
This fixes: `undefined method 'root' for Rails:Module` in a non-Rails project but where the Rails module is still defined.

I'm not sure exactly what causes this to happen. It seems to be a similar problem to this: https://github.com/sevenwire/forgery/issues/5. My guess is that some gem is including Rails in my project, but it's not being configured / set up properly.

Wasn't sure what kind of tests would need to be written to get this accepted, but I did confirm that it fixes the issues I'm having in my Goliath app.

Thanks for taking the time to check this out
