### PR TITLE
Adding link to smtp_settings options list

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ Whatever::Application.config.middleware.use ExceptionNotification::Rack,
   }
 ```
 
+A complete list of `smtp_settings` options can be found in the [ActionMailer Configuration documentation](http://api.rubyonrails.org/classes/ActionMailer/Base.html#class-ActionMailer::Base-label-Configuration+options).
+
 
 ##### mailer_parent
 


### PR DESCRIPTION
Supplementing README by adding a link to the ActionMailer Configuration documentation for a complete list of configuration keys for `smtp_settings`.
