### PR TITLE
Add ActionController::UnknownFormat to ignored exceptions by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ You can choose to ignore certain exceptions, which will make ExceptionNotificati
 
 ### :ignore_exceptions
 
-*Array of strings, default: %w{ActiveRecord::RecordNotFound AbstractController::ActionNotFound ActionController::RoutingError}*
+*Array of strings, default: %w{ActiveRecord::RecordNotFound AbstractController::ActionNotFound ActionController::RoutingError ActionController::UnknownFormat}*
 
 Ignore specified exception types. To achieve that, you should use the `:ignore_exceptions` option, like this:
 

--- a/lib/exception_notifier.rb
+++ b/lib/exception_notifier.rb
@@ -18,7 +18,7 @@ module ExceptionNotifier
 
   # Define a set of exceptions to be ignored, ie, dont send notifications when any of them are raised.
   mattr_accessor :ignored_exceptions
-  @@ignored_exceptions = %w{ActiveRecord::RecordNotFound AbstractController::ActionNotFound ActionController::RoutingError}
+  @@ignored_exceptions = %w{ActiveRecord::RecordNotFound AbstractController::ActionNotFound ActionController::RoutingError ActionController::UnknownFormat}
 
   class << self
     # Store conditions that decide when exceptions must be ignored or not.

--- a/test/exception_notifier_test.rb
+++ b/test/exception_notifier_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ExceptionNotifierTest < ActiveSupport::TestCase
   test "should have default ignored exceptions" do
-    assert ExceptionNotifier.ignored_exceptions == ['ActiveRecord::RecordNotFound', 'AbstractController::ActionNotFound', 'ActionController::RoutingError']
+    assert ExceptionNotifier.ignored_exceptions == ['ActiveRecord::RecordNotFound', 'AbstractController::ActionNotFound', 'ActionController::RoutingError', 'ActionController::UnknownFormat']
   end
 
   test "should have email notifier registered" do


### PR DESCRIPTION
After the release of Rails 4 `respond_to` with `respond_with` became throw an exception `ActionController::UnknownFormat` instead of returning a `406 Unacceptable` status directly. However, this is not an exceptional situation requiring notification because the exception is rescued and converted to 406 in the exception handling middleware.

So, i add `ActionController::UnknownFormat` exception  to ignored exceptions by default.

Thanks!
