### PR TITLE
Adds a throttle notifier to throttle any notifier

### DIFF
--- a/lib/exception_notifier/throttle_notifier.rb
+++ b/lib/exception_notifier/throttle_notifier.rb
@@ -1,0 +1,23 @@
+module ExceptionNotifier
+  class ThrottleNotifier
+    def initialize options={}
+      @notifier = ExceptionNotifier.create_notifier(options[:notifier], options[:notifier_options] || {})
+      @max_notifications_per_hour = 3
+      @past_exceptions = Hash.new {|h,k| h[k] = []}
+    end
+
+    def call(exception, options={})
+      key = exception.class.to_s.each_byte.reduce(&:+)
+
+      past_times = @past_exceptions[key]
+      past_times.reject! {|t| (Time.now - t) >= 3600}
+      past_times << Time.now
+
+      if past_times.size <= @max_notifications_per_hour
+        @notifier.call exception, options
+      else
+        ExceptionNotifier::logger.warn "An exception occurred (#{exception}) and the notifier #{@notifier} was throttled."
+      end
+    end
+  end
+end

--- a/test/exception_notifier/throttle_notifier_test.rb
+++ b/test/exception_notifier/throttle_notifier_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class ThrottleNotifierTest < ActiveSupport::TestCase
+  setup do
+    @throttle = ExceptionNotifier::ThrottleNotifier.new notifier: :email
+    @notifier = @throttle.instance_variable_get "@notifier"
+  end
+
+  test "should delegate to notifier by default" do
+    exception = Exception.new
+    options = {}
+    @notifier.expects(:call).with(exception, options)
+
+    @throttle.call exception, options
+  end
+
+  test "should stop delegating after three equivalent exceptions occur" do
+    exception = Exception.new
+    options = {}
+    @notifier.expects(:call).with(exception, options).times(3)
+    ExceptionNotifier::logger.expects(:warn).stubs(:warn)
+
+    4.times { @throttle.call exception, options }
+  end
+
+  test "should resume delegating after an hour has passed" do
+    Time.stubs(:now).returns(Time.new 2000,1,1,1)
+    exception = Exception.new
+    options = {}
+    @notifier.stubs(:call)
+    ExceptionNotifier::logger.expects(:warn).times(2).stubs(:warn)
+
+    4.times { @throttle.call exception, options }
+
+    Time.stubs(:now).returns(Time.new 2000,1,1,2)
+    @notifier.expects(:call).with(exception, options).times(3)
+
+    4.times { @throttle.call exception, options }
+  end
+end
+


### PR DESCRIPTION
This PR adds a built-in notifier to throttle any notifier. It will notify the underlying notifier a maximum of 3 times every hour.
