### PR TITLE
Add support for HipChat APIv2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       faraday (>= 0.7.4, < 0.9)
     hashie (1.2.0)
     hike (1.2.1)
-    hipchat (0.11.0)
+    hipchat (1.2.0)
       httparty
     http_parser.rb (0.5.3)
     httparty (0.10.2)
@@ -79,8 +79,8 @@ GEM
     mime-types (1.19)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
-    multi_json (1.3.6)
-    multi_xml (0.5.3)
+    multi_json (1.10.1)
+    multi_xml (0.5.5)
     multipart-post (1.2.0)
     polyglot (0.3.3)
     rack (1.4.1)
@@ -162,7 +162,7 @@ DEPENDENCIES
   carrier-pigeon (>= 0.7.0)
   coveralls (~> 0.6.5)
   exception_notification!
-  hipchat (>= 0.11.0)
+  hipchat (>= 1.0.0)
   httparty (~> 0.10.2)
   mocha (>= 0.13.0)
   rails (>= 3.0.4)

--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sqlite3", ">= 1.3.4"
   s.add_development_dependency "coveralls", "~> 0.6.5"
   s.add_development_dependency "appraisal", "~> 1.0.0"
-  s.add_development_dependency "hipchat", ">= 0.11.0"
+  s.add_development_dependency "hipchat", ">= 1.0.0"
   s.add_development_dependency "carrier-pigeon", ">= 0.7.0"
 end

--- a/lib/exception_notifier/hipchat_notifier.rb
+++ b/lib/exception_notifier/hipchat_notifier.rb
@@ -9,8 +9,11 @@ module ExceptionNotifier
       begin
         api_token         = options.delete(:api_token)
         room_name         = options.delete(:room_name)
+        opts              = {
+                              :api_version => options.delete(:api_version) || 'v1'
+                            }
         @from             = options.delete(:from) || 'Exception'
-        @room             = HipChat::Client.new(api_token)[room_name]
+        @room             = HipChat::Client.new(api_token, opts)[room_name]
         @message_template = options.delete(:message_template) || ->(exception) {
           "A new exception occurred: '#{exception.message}' on '#{exception.backtrace.first}'"
         }

--- a/test/exception_notifier/hipchat_notifier_test.rb
+++ b/test/exception_notifier/hipchat_notifier_test.rb
@@ -35,7 +35,7 @@ class HipchatNotifierTest < ActiveSupport::TestCase
       :room_name => 'test_room'
     }
 
-    HipChat::Client.stubs(:new).with('bad_token').returns(nil)
+    HipChat::Client.stubs(:new).with('bad_token', {:api_version => 'v1'}).returns(nil)
 
     hipchat = ExceptionNotifier::HipchatNotifier.new(wrong_params)
     assert_nil hipchat.room
@@ -44,7 +44,7 @@ class HipchatNotifierTest < ActiveSupport::TestCase
   test "should not send hipchat notification if api_key is missing" do
     wrong_params  = {:room_name => 'test_room'}
 
-    HipChat::Client.stubs(:new).with(nil).returns(nil)
+    HipChat::Client.stubs(:new).with(nil, {:api_version => 'v1'}).returns(nil)
 
     hipchat = ExceptionNotifier::HipchatNotifier.new(wrong_params)
     assert_nil hipchat.room
@@ -53,7 +53,7 @@ class HipchatNotifierTest < ActiveSupport::TestCase
   test "should not send hipchat notification if room_name is missing" do
     wrong_params  = {:api_token => 'good_token'}
 
-    HipChat::Client.stubs(:new).with('good_token').returns({})
+    HipChat::Client.stubs(:new).with('good_token', {:api_version => 'v1'}).returns({})
 
     hipchat = ExceptionNotifier::HipchatNotifier.new(wrong_params)
     assert_nil hipchat.room
@@ -68,6 +68,31 @@ class HipchatNotifierTest < ActiveSupport::TestCase
     }
 
     HipChat::Room.any_instance.expects(:send).with('Exception', "This is custom message: '#{fake_exception.message}'", { :color => 'yellow' })
+
+    hipchat = ExceptionNotifier::HipchatNotifier.new(options)
+    hipchat.call(fake_exception)
+  end
+
+  test "should use APIv1 if api_version is not specified" do
+    options = {
+      :api_token => 'good_token',
+      :room_name => 'room_name',
+    }
+
+    HipChat::Client.stubs(:new).with('good_token', {:api_version => 'v1'}).returns({})
+
+    hipchat = ExceptionNotifier::HipchatNotifier.new(options)
+    hipchat.call(fake_exception)
+  end
+
+  test "should use APIv2 when specified" do
+    options = {
+      :api_token => 'good_token',
+      :room_name => 'room_name',
+      :api_version => 'v2',
+    }
+
+    HipChat::Client.stubs(:new).with('good_token', {:api_version => 'v2'}).returns({})
 
     hipchat = ExceptionNotifier::HipchatNotifier.new(options)
     hipchat.call(fake_exception)


### PR DESCRIPTION
This bumps the requirement for the hipchat gem up to >= 1.0.0, where the
APIv2 functionality was first added. In the interest of backwards
compatibility, it explicitly keeps the default API version at v1, in
case the hipchat gem ever switches its default to v2.

Note: This is a more complete version of #229 from @twiduch.
