### PR TITLE
Add additional_parameters hash to slack notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,10 @@ Whatever::Application.config.middleware.use ExceptionNotification::Rack,
   :slack => {
     :team => "myteam",
     :token => "secret-token",
-    :channel => "#exceptions"
+    :channel => "#exceptions",
+    :additional_parameters => {
+      :icon_url => "http://image.jpg"
+    }
   }
 ```
 
@@ -609,6 +612,12 @@ Username of the bot. Default: 'ExceptionNotifierBot'.
 
 Custom hook name. See [slack-notifier](https://github.com/stevenosloan/slack-notifier#custom-hook-name) for
 more information. Default: 'incoming-webhook'
+
+##### additional_parameters
+
+*Hash of strings, optional*
+
+Contains additional payload for a message (e.g avatar, attachments, etc). See [slack-notifier](https://github.com/stevenosloan/slack-notifier#additional-parameters) for more information.. Default: '{}'
 
 ### Custom notifier
 

--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -9,6 +9,7 @@ module ExceptionNotifier
         token = options.fetch(:token)
         custom_hook = options.fetch(:custom_hook, nil)
         options[:username] ||= 'ExceptionNotifierBot'
+        @message_opts = options.fetch(:additional_parameters, {})
 
         if custom_hook.nil?
           @notifier = Slack::Notifier.new team, token, options
@@ -22,7 +23,7 @@ module ExceptionNotifier
 
     def call(exception, options={})
       message = "An exception occurred: '#{exception.message}' on '#{exception.backtrace.first}'"
-      @notifier.ping message if valid?
+      @notifier.ping(message, @message_opts) if valid?
     end
 
     protected

--- a/test/exception_notifier/slack_notifier_test.rb
+++ b/test/exception_notifier/slack_notifier_test.rb
@@ -9,7 +9,7 @@ class SlackNotifierTest < ActiveSupport::TestCase
       team:  "team"
     }
 
-    Slack::Notifier.any_instance.expects(:ping).with(fake_notification)
+    Slack::Notifier.any_instance.expects(:ping).with(fake_notification, {})
 
     slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
     slack_notifier.call(fake_exception)
@@ -22,12 +22,12 @@ class SlackNotifierTest < ActiveSupport::TestCase
       custom_hook: "custom"
     }
 
-    Slack::Notifier.any_instance.expects(:ping).with(fake_notification)
+    Slack::Notifier.any_instance.expects(:ping).with(fake_notification, {})
 
     slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
     slack_notifier.call(fake_exception)
 
-    assert_equal slack_notifier.notifier.hook_name, options[:custom_hook]
+    assert_equal slack_notifier.notifier.hook_name, "custom"
   end
 
   test "should send the notification to the specified channel" do
@@ -37,7 +37,7 @@ class SlackNotifierTest < ActiveSupport::TestCase
       channel: "channel"
     }
 
-    Slack::Notifier.any_instance.expects(:ping).with(fake_notification)
+    Slack::Notifier.any_instance.expects(:ping).with(fake_notification, {})
 
     slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
     slack_notifier.call(fake_exception)
@@ -52,12 +52,43 @@ class SlackNotifierTest < ActiveSupport::TestCase
       username: "username"
     }
 
-    Slack::Notifier.any_instance.expects(:ping).with(fake_notification)
+    Slack::Notifier.any_instance.expects(:ping).with(fake_notification, {})
 
     slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
     slack_notifier.call(fake_exception)
 
     assert_equal slack_notifier.notifier.username, options[:username]
+  end
+
+  test "should have the username 'ExceptionNotifierBot' when unspecified" do
+    options = {
+      token: "token",
+      team:  "team",
+    }
+
+    Slack::Notifier.any_instance.expects(:ping).with(fake_notification, {})
+
+    slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
+    slack_notifier.call(fake_exception)
+
+    assert_equal slack_notifier.notifier.username, 'ExceptionNotifierBot'
+  end
+
+  test "should pass the additional parameters to Slack::Notifier.ping" do
+    options = {
+      token: "token",
+      team:  "team",
+      username: "test",
+      custom_hook: "hook",
+      additional_parameters: {
+        icon_url: "icon",
+      }
+    }
+
+    Slack::Notifier.any_instance.expects(:ping).with(fake_notification, {icon_url: "icon"})
+
+    slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
+    slack_notifier.call(fake_exception)
   end
 
   test "shouldn't send a slack notification if token is missing" do


### PR DESCRIPTION
I somehow manage to completely overlook slack-notifier's additional parameters, which are used to set the bot's avatar, add attachments, etc...
I updated the README accordingly.
