### PR TITLE
Add 'require exception_notification' to template

### DIFF
--- a/lib/generators/exception_notification/templates/exception_notification.rb
+++ b/lib/generators/exception_notification/templates/exception_notification.rb
@@ -1,3 +1,4 @@
+require 'exception_notification'
 require 'exception_notification/rails'
 <% if options.sidekiq? %>
 require 'exception_notification/sidekiq'


### PR DESCRIPTION
I add `require 'exception_notification'` to the template because if i use ExceptionNotification as an engine without this require i have an error:
``<class:Engine>': uninitialized constant ExceptionNotification::Engine::ExceptionNotifier (NameError)`