### PR TITLE
Make backtrace cleaning optional

### DIFF
--- a/lib/exception_notification/rack.rb
+++ b/lib/exception_notification/rack.rb
@@ -5,6 +5,8 @@ module ExceptionNotification
 
       ExceptionNotifier.ignored_exceptions = options.delete(:ignore_exceptions) if options.key?(:ignore_exceptions)
 
+      ExceptionNotifier.clean_backtrace = options.delete(:clean_backtrace) if options.key?(:clean_backtrace)
+
       if options.key?(:ignore_if)
         rack_ignore = options.delete(:ignore_if)
         ExceptionNotifier.ignore_if do |exception, options|

--- a/lib/exception_notifier.rb
+++ b/lib/exception_notifier.rb
@@ -22,6 +22,10 @@ module ExceptionNotifier
   mattr_accessor :ignored_exceptions
   @@ignored_exceptions = %w{ActiveRecord::RecordNotFound AbstractController::ActionNotFound ActionController::RoutingError ActionController::UnknownFormat}
 
+  # Setting for whether backtraces should be cleaned in the EmailNorifier
+  mattr_accessor :clean_backtrace
+  @@clean_backtrace = true
+
   class << self
     # Store conditions that decide when exceptions must be ignored or not.
     @@ignores = []

--- a/lib/exception_notifier/email_notifier.rb
+++ b/lib/exception_notifier/email_notifier.rb
@@ -40,7 +40,7 @@ module ExceptionNotifier
 
             @exception = exception
             @options   = options.reverse_merge(default_options)
-            @backtrace = exception.backtrace || []
+            @backtrace = exception.backtrace ? clean_backtrace(exception) : []
             @sections  = @options[:background_sections]
             @data      = options[:data] || {}
 
@@ -65,7 +65,7 @@ module ExceptionNotifier
           end
 
           def clean_backtrace(exception)
-            if defined?(Rails) && Rails.respond_to?(:backtrace_cleaner)
+            if ExceptionNotifier.clean_backtrace && defined?(Rails) && Rails.respond_to?(:backtrace_cleaner)
               Rails.backtrace_cleaner.send(:filter, exception.backtrace)
             else
               exception.backtrace

--- a/test/exception_notifier/email_notifier_test.rb
+++ b/test/exception_notifier/email_notifier_test.rb
@@ -2,15 +2,26 @@ require 'test_helper'
 
 class EmailNotifierTest < ActiveSupport::TestCase
   setup do
+    @clean_backtrace = ExceptionNotifier.clean_backtrace
+    ExceptionNotifier.clean_backtrace = true
+
     Time.stubs(:current).returns('Sat, 20 Apr 2013 20:58:55 UTC +00:00')
     @email_notifier = ExceptionNotifier.registered_exception_notifier(:email)
+
     begin
       1/0
     rescue => e
       @exception = e
+
+      Rails.backtrace_cleaner.stubs(:filter).returns(@exception.backtrace.take(2))
+
       @mail = @email_notifier.create_email(@exception,
         :data => {:job => 'DivideWorkerJob', :payload => '1/0', :message => 'My Custom Message'})
     end
+  end
+
+  teardown do
+    ExceptionNotifier.clean_backtrace = @clean_backtrace
   end
 
   test "should have default sender address overridden" do
@@ -113,8 +124,24 @@ class EmailNotifierTest < ActiveSupport::TestCase
     assert @vowel_mail.encoded.include? "An ActiveRecord::RecordNotFound occurred in background at #{Time.current}"
   end
 
-  test "mail should contain backtrace in body" do
-    assert @mail.encoded.include?("test/exception_notifier/email_notifier_test.rb:8"), "\n#{@mail.inspect}"
+  test "mail should contain cleaned backtrace in body" do
+    assert_include @mail.encoded, @exception.backtrace[0], "\n#{@mail}"
+    assert_include @mail.encoded, @exception.backtrace[1], "\n#{@mail}"
+
+    assert_not_include @mail.encoded, @exception.backtrace[2], "\n#{@mail}"
+    assert_not_include @mail.encoded, @exception.backtrace[-1], "\n#{@mail}"
+  end
+
+  test "mail should contain uncleaned backtrace in body if backtrace cleaning is disabled" do
+    ExceptionNotifier.clean_backtrace = false
+
+    @mail = @email_notifier.create_email(@exception,
+      :data => {:job => 'DivideWorkerJob', :payload => '1/0', :message => 'My Custom Message'})
+
+    assert_include @mail.encoded, @exception.backtrace[0], "\n#{@mail.inspect}"
+    assert_include @mail.encoded, @exception.backtrace[1], "\n#{@mail.inspect}"
+    assert_include @mail.encoded, @exception.backtrace[2], "\n#{@mail.inspect}"
+    assert_include @mail.encoded, @exception.backtrace[-1], "\n#{@mail.inspect}"
   end
 
   test "mail should contain data in body" do


### PR DESCRIPTION
Hello!

This is a starting point to fix #228. It adds a new config `clean_backtrace` (defaults to `true`) for changing whether backtraces should be cleaned.

Also fixed a bug where the backtrace of background exceptions are not ran through the backtrace cleaner currently – I'm unsure if this was intentional, but it was easier to "fix" this so that the test would pass. If that's unacceptable, feel free to pick it up from here and improve the code.

To maintain the current behavior, the new option is defaulted to `true`. However, personally, I feel that this whole feature (backtrace cleaning) is of dubious values in these exception emails. I came across this when helping a client debug an error they are encountering, but unfortunately the error is originated from a gem so I didn't have any backtrace to look at. It seems like you would always want to have more information in these reports... I'm not sure if there's much value in having the option to clean the backtrace in the first place in this context.

The backtrace cleaning code is also only used in the `EmailNotifier`, so if this is staying, it should probably be moved up one layer so that it would be consistent across the `WebhookNotifier` (for example) and the chat notifiers as well (in theory, the cleaner could remove some of the top frames in the backtrace as well).

Like I said, this is only a starting point, so if it doesn't fit your needs for some reason, feel free to pick it up and improve it or reimplement in another way. Would love to see this feature go into the master branch eventually!

Thanks for reviewing this, hope it helps! :heart: :yellow_heart: :green_heart: :blue_heart: :purple_heart:

Fixes #228