### PR TITLE
fix dependencies

### DIFF
--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   if RUBY_VERSION > "2.0"
     s.add_development_dependency "sidekiq", "~> 3.3"
   else
-    s.add_development_dependency "sidekiq", "~> 3.2.6"
+    s.add_development_dependency "sidekiq", "~> 2.17.8"
   end
   s.add_development_dependency "tinder", "~> 1.8"
   s.add_development_dependency "httparty", "~> 0.10.2"

--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rails", ">= 3.0.4"
   s.add_development_dependency "resque", "~> 1.2.0"
-  if RUBY_VERSION > "1.9"
-    s.add_development_dependency "sidekiq", "~> 3.3"
+  if RUBY_VERSION < "2.0"
+    s.add_development_dependency "sidekiq", "~> 3.2.6"
   else
-    s.add_development_dependency "sidekiq", "~> 3.2.6"  
+    s.add_development_dependency "sidekiq", "~> 3.3"
   end
   s.add_development_dependency "tinder", "~> 1.8"
   s.add_development_dependency "httparty", "~> 0.10.2"

--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -21,7 +21,11 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rails", ">= 3.0.4"
   s.add_development_dependency "resque", "~> 1.2.0"
-  s.add_development_dependency "sidekiq", "~> 3.0"
+  if RUBY_VERSION > "1.9"
+    s.add_development_dependency "sidekiq", "~> 3.3"
+  else
+    s.add_development_dependency "sidekiq", "~> 3.2.6"  
+  end
   s.add_development_dependency "tinder", "~> 1.8"
   s.add_development_dependency "httparty", "~> 0.10.2"
   s.add_development_dependency "mocha", ">= 0.13.0"

--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rails", ">= 3.0.4"
   s.add_development_dependency "resque", "~> 1.2.0"
-  if RUBY_VERSION < "2.0"
-    s.add_development_dependency "sidekiq", "~> 3.2.6"
-  else
+  if RUBY_VERSION > "2.0"
     s.add_development_dependency "sidekiq", "~> 3.3"
+  else
+    s.add_development_dependency "sidekiq", "~> 3.2.6"
   end
   s.add_development_dependency "tinder", "~> 1.8"
   s.add_development_dependency "httparty", "~> 0.10.2"


### PR DESCRIPTION
Since sidekiq 3.3.x was launched, they do not support ruby 1.9 anymore.
https://github.com/mperham/sidekiq#requirements
Suggestion is lock on sidekiq v3.2 if ruby version is 1.9 or less