### PR TITLE
Notify exception without backtrace info

### DIFF
--- a/lib/exception_notifier/campfire_notifier.rb
+++ b/lib/exception_notifier/campfire_notifier.rb
@@ -17,7 +17,11 @@ module ExceptionNotifier
     end
 
     def call(exception, options={})
-      @room.paste "A new exception occurred: '#{exception.message}' on '#{exception.backtrace.first if exception.backtrace}'" if active?
+      if active?
+        message = "A new exception occurred: '#{exception.message}'"
+        message += " on '#{exception.backtrace.first}'" if exception.backtrace
+        @room.paste message message
+      end
     end
 
     private

--- a/lib/exception_notifier/campfire_notifier.rb
+++ b/lib/exception_notifier/campfire_notifier.rb
@@ -17,7 +17,7 @@ module ExceptionNotifier
     end
 
     def call(exception, options={})
-      @room.paste "A new exception occurred: '#{exception.message}' on '#{exception.backtrace.first}'" if active?
+      @room.paste "A new exception occurred: '#{exception.message}' on '#{exception.backtrace.first if exception.backtrace}'" if active?
     end
 
     private

--- a/lib/exception_notifier/hipchat_notifier.rb
+++ b/lib/exception_notifier/hipchat_notifier.rb
@@ -15,7 +15,9 @@ module ExceptionNotifier
         @from             = options.delete(:from) || 'Exception'
         @room             = HipChat::Client.new(api_token, opts)[room_name]
         @message_template = options.delete(:message_template) || ->(exception) {
-          "A new exception occurred: '#{exception.message}' on '#{exception.backtrace.first if exception.backtrace}'"
+          msg = "A new exception occurred: '#{exception.message}'"
+          msg += " on '#{exception.backtrace.first}'" if exception.backtrace
+          msg
         }
         @message_options  = options
         @message_options[:color] ||= 'red'

--- a/lib/exception_notifier/hipchat_notifier.rb
+++ b/lib/exception_notifier/hipchat_notifier.rb
@@ -15,7 +15,7 @@ module ExceptionNotifier
         @from             = options.delete(:from) || 'Exception'
         @room             = HipChat::Client.new(api_token, opts)[room_name]
         @message_template = options.delete(:message_template) || ->(exception) {
-          "A new exception occurred: '#{exception.message}' on '#{exception.backtrace.first}'"
+          "A new exception occurred: '#{exception.message}' on '#{exception.backtrace.first if exception.backtrace}'"
         }
         @message_options  = options
         @message_options[:color] ||= 'red'

--- a/lib/exception_notifier/irc_notifier.rb
+++ b/lib/exception_notifier/irc_notifier.rb
@@ -6,7 +6,7 @@ module ExceptionNotifier
     end
 
     def call(exception, options={})
-      message = "'#{exception.message}' on '#{exception.backtrace.first}'"
+      message = "'#{exception.message}' on '#{exception.backtrace.first if exception.backtrace}'"
       send_message([*@config.prefix, *message].join(' ')) if active?
     end
 

--- a/lib/exception_notifier/irc_notifier.rb
+++ b/lib/exception_notifier/irc_notifier.rb
@@ -6,7 +6,8 @@ module ExceptionNotifier
     end
 
     def call(exception, options={})
-      message = "'#{exception.message}' on '#{exception.backtrace.first if exception.backtrace}'"
+      message = "'#{exception.message}'"
+      message += " on '#{exception.backtrace.first}'" if exception.backtrace
       send_message([*@config.prefix, *message].join(' ')) if active?
     end
 

--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -21,7 +21,7 @@ module ExceptionNotifier
       message += " on '#{exception.backtrace.first}'" if exception.backtrace
 
       message = enrich_message_with_data(message, options)
-      message = enrich_message_with_backtrace(message, exception)
+      message = enrich_message_with_backtrace(message, exception) if exception.backtrace
 
       @notifier.ping(message, @message_opts) if valid?
     end

--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -17,7 +17,7 @@ module ExceptionNotifier
     end
 
     def call(exception, options={})
-      message = "An exception occurred: '#{exception.message}' on '#{exception.backtrace.first}'"
+      message = "An exception occurred: '#{exception.message}' on '#{exception.backtrace.first if exception.backtrace}'"
 
       message = enrich_message_with_data(message, options)
       message = enrich_message_with_backtrace(message, exception)

--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -17,7 +17,8 @@ module ExceptionNotifier
     end
 
     def call(exception, options={})
-      message = "An exception occurred: '#{exception.message}' on '#{exception.backtrace.first if exception.backtrace}'"
+      message = "An exception occurred: '#{exception.message}'"
+      message += " on '#{exception.backtrace.first}'" if exception.backtrace
 
       message = enrich_message_with_data(message, options)
       message = enrich_message_with_backtrace(message, exception)

--- a/test/exception_notifier/hipchat_notifier_test.rb
+++ b/test/exception_notifier/hipchat_notifier_test.rb
@@ -16,6 +16,19 @@ class HipchatNotifierTest < ActiveSupport::TestCase
     hipchat.call(fake_exception)
   end
 
+  test "should send hipchat notification without backtrace info if properly configured" do
+    options = {
+      :api_token => 'good_token',
+      :room_name => 'room_name',
+      :color     => 'yellow',
+    }
+
+    HipChat::Room.any_instance.expects(:send).with('Exception', fake_body_without_backtrace, { :color => 'yellow' })
+
+    hipchat = ExceptionNotifier::HipchatNotifier.new(options)
+    hipchat.call(fake_exception_without_backtrace)
+  end
+
   test "should allow custom from value if set" do
     options = {
       :api_token => 'good_token',
@@ -110,5 +123,13 @@ class HipchatNotifierTest < ActiveSupport::TestCase
     rescue Exception => e
       e
     end
+  end
+
+  def fake_body_without_backtrace
+    "A new exception occurred: '#{fake_exception_without_backtrace.message}'"
+  end
+
+  def fake_exception_without_backtrace
+    StandardError.new('my custom error')
   end
 end

--- a/test/exception_notifier/irc_notifier_test.rb
+++ b/test/exception_notifier/irc_notifier_test.rb
@@ -16,6 +16,19 @@ class IrcNotifierTest < ActiveSupport::TestCase
     irc.call(fake_exception)
   end
 
+  test "should send irc notification without backtrace info if properly configured" do
+    options = {
+      :domain => 'irc.example.com'
+    }
+
+    CarrierPigeon.expects(:send).with(has_key(:uri)) do |v|
+      /my custom error/.match(v[:message])
+    end
+
+    irc = ExceptionNotifier::IrcNotifier.new(options)
+    irc.call(fake_exception_without_backtrace)
+  end
+
   test "should properly construct URI from constituent parts" do
     options = {
       :nick => 'BadNewsBot',
@@ -81,5 +94,9 @@ class IrcNotifierTest < ActiveSupport::TestCase
     rescue Exception => e
       e
     end
+  end
+
+  def fake_exception_without_backtrace
+    StandardError.new('my custom error')
   end
 end

--- a/test/exception_notifier/slack_notifier_test.rb
+++ b/test/exception_notifier/slack_notifier_test.rb
@@ -20,6 +20,17 @@ class SlackNotifierTest < ActiveSupport::TestCase
     slack_notifier.call(@exception)
   end
 
+  test "should send a slack notification without backtrace info if properly configured" do
+    options = {
+      webhook_url: "http://slack.webhook.url"
+    }
+
+    Slack::Notifier.any_instance.expects(:ping).with(fake_notification_without_backtrace, {})
+
+    slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
+    slack_notifier.call(fake_exception_without_backtrace)
+  end
+
   test "should send the notification to the specified channel" do
     options = {
       webhook_url: "http://slack.webhook.url",
@@ -113,5 +124,13 @@ class SlackNotifierTest < ActiveSupport::TestCase
     message = "An exception occurred: '#{exception.message}' on '#{exception.backtrace.first}'\n"
     message += "*Data:*\n#{data_string}\n" unless data_string.nil?
     message += "*Backtrace:*\n" + exception.backtrace.join("\n")
+  end
+
+  def fake_exception_without_backtrace
+    StandardError.new('my custom error')
+  end
+
+  def fake_notification_without_backtrace
+    message = "An exception occurred: '#{fake_exception_without_backtrace.message}'"
   end
 end


### PR DESCRIPTION
I'd like to notify exception without raising exception like this:

```
ExceptionNotifier.notify_exception(StandardError.new('my custom error!'))
```

But I got an error:

```
NoMethodError: undefined method `first' for nil:NilClass
```

This is because `call` method requires backtrace.

This PR makes backtrace optional by checking if an exception has a backtrace.