### PR TITLE
Notify on Rails 404s

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,6 +719,17 @@ Whatever::Application.config.middleware.use ExceptionNotification::Rack,
 
 You can make use of both the environment and the exception inside the lambda to decide wether to avoid or not sending the notification.
 
+## Rack X-Cascade Header
+
+Some rack apps (Rails in particular) utilize the "X-Cascade" header to pass the request-handling responsibility to the next middleware in the stack.
+
+Rails' routing middleware uses this strategy, rather than raising an exception, to handle routing errors (e.g. 404s); to be notified whenever a 404 occurs, set this option to "false."
+
+### :ignore_cascade_pass
+
+*Boolean, default: true*
+
+Set to false to trigger notifications when another rack middleware sets the "X-Cascade" header to "pass."
 
 ## Background Notifications
 

--- a/lib/exception_notification/rack.rb
+++ b/lib/exception_notification/rack.rb
@@ -21,6 +21,8 @@ module ExceptionNotification
         end
       end
 
+      @ignore_cascade_pass = options.delete(:ignore_cascade_pass) { true }
+
       options.each do |notifier_name, options|
         ExceptionNotifier.register_exception_notifier(notifier_name, options)
       end
@@ -29,7 +31,7 @@ module ExceptionNotification
     def call(env)
       _, headers, _ = response = @app.call(env)
 
-      if headers['X-Cascade'] == 'pass'
+      if !@ignore_cascade_pass && headers['X-Cascade'] == 'pass'
         msg = "This exception means that the preceding Rack middleware set the 'X-Cascade' header to 'pass' -- in " <<
           "Rails, this often means that the route was not found (404 error)."
         raise CascadePassException, msg

--- a/test/exception_notification/rack_test.rb
+++ b/test/exception_notification/rack_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class RackTest < ActiveSupport::TestCase
+
+  setup do
+    @pass_app = Object.new
+    @pass_app.stubs(:call).returns([nil, { 'X-Cascade' => 'pass' }, nil])
+  end
+
+  test "should ignore \"X-Cascade\" header by default" do
+    ExceptionNotifier.expects(:notify_exception).never
+    ExceptionNotification::Rack.new(@pass_app).call({})
+  end
+
+  test "should notify on \"X-Cascade\" = \"pass\" if ignore_cascade_pass option is false" do
+    ExceptionNotifier.expects(:notify_exception).once
+    ExceptionNotification::Rack.new(@pass_app, :ignore_cascade_pass => false).call({})
+  end
+
+end


### PR DESCRIPTION
Some rack apps (Rails in particular) utilize the "X-Cascade" header to pass the request-handling responsibility to the next middleware in the stack.

Rails' routing middleware uses this strategy, rather than raising an exception, to handle routing errors (e.g. 404s).

This adds the following option:

:ignore_cascade_pass
*Boolean, default: true*

Set to false to trigger notifications when another rack middleware sets the "X-Cascade" header to "pass."

Tests and README update included.

Please let me know if I've missed something or if there's a more appropriate spot or a better way to handle this scenario.