### PR TITLE
Use environment data in Slack exception message

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ Just add the [slack-notifier](https://github.com/stevenosloan/slack-notifier) ge
 gem 'slack-notifier'
 ```
 
-To configure it, you need to set at least the 'team' and 'token' options, like this:
+To configure it, you need to set at least the 'webhook_url' option, like this:
 
 ```ruby
 Whatever::Application.config.middleware.use ExceptionNotification::Rack,
@@ -574,10 +574,30 @@ Whatever::Application.config.middleware.use ExceptionNotification::Rack,
     :webhook_url => "[Your webhook url]",
     :channel => "#exceptions",
     :additional_parameters => {
-      :icon_url => "http://image.jpg"
+      :icon_url => "http://image.jpg",
+      :mrkdwn => true
     }
   }
 ```
+
+The slack notification will include any data saved under `env["exception_notifier.exception_data"]`. If you find this too verbose, you can determine to exclude certain information by doing the following:
+
+```ruby
+Whatever::Application.config.middleware.use ExceptionNotification::Rack,
+  :slack => {
+    :webhook_url => "[Your webhook url]",
+    :channel => "#exceptions",
+    :additional_parameters => {
+      :icon_url => "http://image.jpg",
+      :mrkdwn => true
+    },
+    :ignore_data_if => lambda {|key, value|
+      "#{key}" == 'key_to_ignore' || value.is_a?(ClassToBeIgnored)
+    }
+  }
+```
+
+Any evaluation to `true` will cause the key / value pair not be be sent along to Slack.
 
 #### Options
 

--- a/lib/exception_notifier.rb
+++ b/lib/exception_notifier.rb
@@ -4,6 +4,8 @@ require 'active_support/core_ext/module/attribute_accessors'
 
 module ExceptionNotifier
 
+  autoload :BacktraceCleaner, 'exception_notifier/modules/backtrace_cleaner'
+
   autoload :Notifier, 'exception_notifier/notifier'
   autoload :EmailNotifier, 'exception_notifier/email_notifier'
   autoload :CampfireNotifier, 'exception_notifier/campfire_notifier'

--- a/lib/exception_notifier/email_notifier.rb
+++ b/lib/exception_notifier/email_notifier.rb
@@ -17,6 +17,8 @@ module ExceptionNotifier
 
       def self.extended(base)
         base.class_eval do
+          base.include BacktraceCleaner
+
           # Append application view path to the ExceptionNotifier lookup context.
           self.append_view_path "#{File.dirname(__FILE__)}/views"
 
@@ -62,14 +64,6 @@ module ExceptionNotifier
           def set_data_variables
             @data.each do |name, value|
               instance_variable_set("@#{name}", value)
-            end
-          end
-
-          def clean_backtrace(exception)
-            if defined?(Rails) && Rails.respond_to?(:backtrace_cleaner)
-              Rails.backtrace_cleaner.send(:filter, exception.backtrace)
-            else
-              exception.backtrace
             end
           end
 

--- a/lib/exception_notifier/modules/backtrace_cleaner.rb
+++ b/lib/exception_notifier/modules/backtrace_cleaner.rb
@@ -1,0 +1,11 @@
+module BacktraceCleaner
+
+  def clean_backtrace(exception)
+    if defined?(Rails) && Rails.respond_to?(:backtrace_cleaner)
+      Rails.backtrace_cleaner.send(:filter, exception.backtrace)
+    else
+      exception.backtrace
+    end
+  end
+
+end

--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -15,7 +15,7 @@ module ExceptionNotifier
 
     def call(exception, options={})
       message = "An exception occurred: '#{exception.message}' on '#{exception.backtrace.first}'"
-      message = enrich_message_with_data(message, options[:env] || {})
+      message = enrich_message_with_data(message, options)
 
       @notifier.ping(message, @message_opts) if valid?
     end
@@ -26,11 +26,12 @@ module ExceptionNotifier
       !@notifier.nil?
     end
 
-    def enrich_message_with_data(message, env)
-      data = (env['exception_notifier.exception_data'] || {}).map{|k,v| "#{k}: #{v}"}.join(', ')
+    def enrich_message_with_data(message, options)
+      data = ((options[:env] || {})['exception_notifier.exception_data'] || {}).merge(options[:data] || {})
+      text = data.map{|k,v| "#{k}: #{v}"}.join(', ')
 
-      if data.present?
-        message + " - #{data}"
+      if text.present?
+        message + " - #{text}"
       else
         message
       end

--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -15,6 +15,8 @@ module ExceptionNotifier
 
     def call(exception, options={})
       message = "An exception occurred: '#{exception.message}' on '#{exception.backtrace.first}'"
+      message = enrich_message_with_data(message, options[:env] || {})
+
       @notifier.ping(message, @message_opts) if valid?
     end
 
@@ -23,5 +25,16 @@ module ExceptionNotifier
     def valid?
       !@notifier.nil?
     end
+
+    def enrich_message_with_data(message, env)
+      data = (env['exception_notifier.exception_data'] || {}).map{|k,v| "#{k}: #{v}"}.join(', ')
+
+      if data.present?
+        message + " - #{data}"
+      else
+        message
+      end
+    end
+
   end
 end

--- a/test/exception_notifier/slack_notifier_test.rb
+++ b/test/exception_notifier/slack_notifier_test.rb
@@ -75,10 +75,13 @@ class SlackNotifierTest < ActiveSupport::TestCase
     notification_options = {
       env: {
         'exception_notifier.exception_data' => {foo: 'bar', john: 'doe'}
+      },
+      data: {
+        'user_id' => 5
       }
     }
 
-    Slack::Notifier.any_instance.expects(:ping).with(fake_notification + ' - foo: bar, john: doe', {})
+    Slack::Notifier.any_instance.expects(:ping).with(fake_notification + ' - foo: bar, john: doe, user_id: 5', {})
     slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
     slack_notifier.call(fake_exception, notification_options)
   end

--- a/test/exception_notifier/slack_notifier_test.rb
+++ b/test/exception_notifier/slack_notifier_test.rb
@@ -67,6 +67,22 @@ class SlackNotifierTest < ActiveSupport::TestCase
     assert_nil slack_notifier.call(fake_exception)
   end
 
+  test "should pass along environment data" do
+    options = {
+      webhook_url: "http://slack.webhook.url"
+    }
+
+    notification_options = {
+      env: {
+        'exception_notifier.exception_data' => {foo: 'bar', john: 'doe'}
+      }
+    }
+
+    Slack::Notifier.any_instance.expects(:ping).with(fake_notification + ' - foo: bar, john: doe', {})
+    slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
+    slack_notifier.call(fake_exception, notification_options)
+  end
+
   private
 
   def fake_exception

--- a/test/exception_notifier/slack_notifier_test.rb
+++ b/test/exception_notifier/slack_notifier_test.rb
@@ -3,6 +3,12 @@ require 'slack-notifier'
 
 class SlackNotifierTest < ActiveSupport::TestCase
 
+  def setup
+    @exception = fake_exception
+    @exception.stubs(:backtrace).returns(["backtrace line 1", "backtrace line 2"])
+    @exception.stubs(:message).returns('exception message')
+  end
+
   test "should send a slack notification if properly configured" do
     options = {
       webhook_url: "http://slack.webhook.url"
@@ -11,7 +17,7 @@ class SlackNotifierTest < ActiveSupport::TestCase
     Slack::Notifier.any_instance.expects(:ping).with(fake_notification, {})
 
     slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
-    slack_notifier.call(fake_exception)
+    slack_notifier.call(@exception)
   end
 
   test "should send the notification to the specified channel" do
@@ -23,7 +29,7 @@ class SlackNotifierTest < ActiveSupport::TestCase
     Slack::Notifier.any_instance.expects(:ping).with(fake_notification, {})
 
     slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
-    slack_notifier.call(fake_exception)
+    slack_notifier.call(@exception)
 
     assert_equal slack_notifier.notifier.channel, options[:channel]
   end
@@ -37,7 +43,7 @@ class SlackNotifierTest < ActiveSupport::TestCase
     Slack::Notifier.any_instance.expects(:ping).with(fake_notification, {})
 
     slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
-    slack_notifier.call(fake_exception)
+    slack_notifier.call(@exception)
 
     assert_equal slack_notifier.notifier.username, options[:username]
   end
@@ -55,7 +61,7 @@ class SlackNotifierTest < ActiveSupport::TestCase
     Slack::Notifier.any_instance.expects(:ping).with(fake_notification, {icon_url: "icon"})
 
     slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
-    slack_notifier.call(fake_exception)
+    slack_notifier.call(@exception)
   end
 
   test "shouldn't send a slack notification if webhook url is missing" do
@@ -68,12 +74,11 @@ class SlackNotifierTest < ActiveSupport::TestCase
   end
 
   test "should pass along environment data" do
-    exception = fake_exception
-    exception.expects(:backtrace).times(3).returns(["foo line 1", "bar line 20"])
-    exception.expects(:message).twice.returns('exception message')
-
     options = {
-      webhook_url: "http://slack.webhook.url"
+      webhook_url: "http://slack.webhook.url",
+      ignore_data_if: lambda {|k,v|
+        "#{k}" == 'key_to_be_ignored' || v.is_a?(Hash)
+      }
     }
 
     notification_options = {
@@ -81,22 +86,17 @@ class SlackNotifierTest < ActiveSupport::TestCase
         'exception_notifier.exception_data' => {foo: 'bar', john: 'doe'}
       },
       data: {
-        'user_id' => 5,
-        'error_backtrace' => ["ignored backtrace"]
+        'user_id'           => 5,
+        'key_to_be_ignored' => 'whatever',
+        'ignore_as_well'    => {what: 'ever'}
       }
     }
 
-    expected_message =
-      "#{fake_notification(exception)}\n" \
-      "*Data:*\n"                         \
-      "foo: bar, john: doe, user_id: 5\n" \
-      "*Backtrace:*\n"                    \
-      "foo line 1\n"                      \
-      "bar line 20"
+    expected_data_string = 'foo: bar, john: doe, user_id: 5'
 
-    Slack::Notifier.any_instance.expects(:ping).with(expected_message, {})
+    Slack::Notifier.any_instance.expects(:ping).with(fake_notification(@exception, expected_data_string), {})
     slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
-    slack_notifier.call(exception, notification_options)
+    slack_notifier.call(@exception, notification_options)
   end
 
   private
@@ -109,7 +109,9 @@ class SlackNotifierTest < ActiveSupport::TestCase
     end
   end
 
-  def fake_notification(exception=fake_exception)
-    "An exception occurred: '#{exception.message}' on '#{exception.backtrace.first}'"
+  def fake_notification(exception=@exception, data_string=nil)
+    message = "An exception occurred: '#{exception.message}' on '#{exception.backtrace.first}'\n"
+    message += "*Data:*\n#{data_string}\n" unless data_string.nil?
+    message += "*Backtrace:*\n" + exception.backtrace.join("\n")
   end
 end


### PR DESCRIPTION
When using Slack for notification, environment data was not taken into account.