### PR TITLE
Avoid unnecessary context for Module#include call

### DIFF
--- a/lib/exception_notifier/email_notifier.rb
+++ b/lib/exception_notifier/email_notifier.rb
@@ -17,7 +17,7 @@ module ExceptionNotifier
 
       def self.extended(base)
         base.class_eval do
-          base.include BacktraceCleaner
+          include BacktraceCleaner
 
           # Append application view path to the ExceptionNotifier lookup context.
           self.append_view_path "#{File.dirname(__FILE__)}/views"


### PR DESCRIPTION
Module#include was not public until Ruby 2.1.0.  By avoiding calling Module#include off of `base`, we fix the build for Ruby 2.0.0.

h/t @gabrielg