### PR TITLE
Test suite fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
 gemfile:

--- a/test/dummy/test/functional/posts_controller_test.rb
+++ b/test/dummy/test/functional/posts_controller_test.rb
@@ -14,59 +14,59 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   test "should have raised an exception" do
-    assert_not_nil @exception
+    refute_nil @exception
   end
 
   test "should have generated a notification email" do
-    assert_not_nil @mail
+    refute_nil @mail
   end
 
   test "mail should be plain text and UTF-8 enconded by default" do
-    assert @mail.content_type == "text/plain; charset=UTF-8"
+    assert_equal @mail.content_type, "text/plain; charset=UTF-8"
   end
 
   test "mail should have a from address set" do
-    assert @mail.from == ["dummynotifier@example.com"]
+    assert_equal @mail.from, ["dummynotifier@example.com"]
   end
 
   test "mail should have a to address set" do
-    assert @mail.to == ["dummyexceptions@example.com"]
+    assert_equal @mail.to, ["dummyexceptions@example.com"]
   end
 
   test "mail subject should have the proper prefix" do
-    assert @mail.subject.include? "[Dummy ERROR]"
+    assert_includes @mail.subject, "[Dummy ERROR]"
   end
 
   test "mail subject should include descriptive error message" do
-    assert @mail.subject.include? "(NoMethodError) \"undefined method `nw'"
+    assert_includes @mail.subject, "(NoMethodError) \"undefined method `nw'"
   end
 
   test "mail should contain backtrace in body" do
-    assert @mail.encoded.include? "`method_missing'\r\n  app/controllers/posts_controller.rb:18:in `create'\r\n"
+    assert_includes @mail.encoded, "`method_missing'\r\n  app/controllers/posts_controller.rb:18:in `create'\r\n"
   end
 
   test "mail should contain timestamp of exception in body" do
-    assert @mail.encoded.include? "Timestamp  : #{Time.current}"
+    assert_includes @mail.encoded, "Timestamp  : #{Time.current}"
   end
 
   test "mail should contain the newly defined section" do
-    assert @mail.encoded.include? "* New text section for testing"
+    assert_includes @mail.encoded, "* New text section for testing"
   end
 
   test "mail should contain the custom message" do
-    assert @mail.encoded.include? "My Custom Message"
+    assert_includes @mail.encoded, "My Custom Message"
   end
 
   test "should filter sensible data" do
-    assert @mail.encoded.include? "secret\"=>\"[FILTERED]"
+    assert_includes @mail.encoded, "secret\"=>\"[FILTERED]"
   end
 
   test "mail should contain the custom header" do
-    assert @mail.encoded.include? 'X-Custom-Header: foobar'
+    assert_includes @mail.encoded, 'X-Custom-Header: foobar'
   end
 
   test "mail should not contain any attachments" do
-    assert @mail.attachments == []
+    assert_equal @mail.attachments, []
   end
 
   test "should not send notification if one of ignored exceptions" do
@@ -79,7 +79,7 @@ class PostsControllerTest < ActionController::TestCase
       end
     end
 
-    assert @ignored_exception.class.inspect == "ActiveRecord::RecordNotFound"
+    assert_equal @ignored_exception.class.inspect, "ActiveRecord::RecordNotFound"
     assert_nil @ignored_mail
   end
 
@@ -93,7 +93,7 @@ class PostsControllerTest < ActionController::TestCase
     end
 
     assert request.ssl?
-    assert @secured_mail.encoded.include? "* session id: [FILTERED]\r\n  *"
+    assert_includes @secured_mail.encoded, "* session id: [FILTERED]\r\n  *"
   end
 
   test "should ignore exception if from unwanted crawler" do
@@ -127,7 +127,7 @@ class PostsControllerTest < ActionController::TestCase
       @mail = @email_notifier.create_email(@exception, {:env => custom_env})
     end
 
-    assert @mail.content_type.include? "multipart/alternative"
+    assert_includes @mail.content_type, "multipart/alternative"
   end
 end
 
@@ -219,6 +219,6 @@ class PostsControllerTestBackgroundNotification < ActionController::TestCase
   end
 
   test "mail should contain the specified section" do
-    assert @mail.encoded.include? "* New background section for testing"
+    assert_includes @mail.encoded, "* New background section for testing"
   end
 end

--- a/test/exception_notifier/campfire_notifier_test.rb
+++ b/test/exception_notifier/campfire_notifier_test.rb
@@ -11,9 +11,9 @@ class CampfireNotifierTest < ActiveSupport::TestCase
 
     assert !notif[:message].empty?
     assert_equal notif[:message][:type], 'PasteMessage'
-    assert notif[:message][:body].include? "A new exception occurred:"
-    assert notif[:message][:body].include? "divided by 0"
-    assert notif[:message][:body].include? "/exception_notification/test/campfire_test.rb:45"
+    assert_includes notif[:message][:body], "A new exception occurred:"
+    assert_includes notif[:message][:body], "divided by 0"
+    assert_includes notif[:message][:body], "/exception_notification/test/campfire_test.rb:45"
   end
 
   test "should not send campfire notification if badly configured" do

--- a/test/exception_notifier/email_notifier_test.rb
+++ b/test/exception_notifier/email_notifier_test.rb
@@ -14,59 +14,59 @@ class EmailNotifierTest < ActiveSupport::TestCase
   end
 
   test "should have default sender address overridden" do
-    assert @email_notifier.sender_address == %("Dummy Notifier" <dummynotifier@example.com>)
+    assert_equal @email_notifier.sender_address, %("Dummy Notifier" <dummynotifier@example.com>)
   end
 
   test "should have default exception recipients overridden" do
-    assert @email_notifier.exception_recipients == %w(dummyexceptions@example.com)
+    assert_equal @email_notifier.exception_recipients, %w(dummyexceptions@example.com)
   end
 
   test "should have default email prefix overridden" do
-    assert @email_notifier.email_prefix == "[Dummy ERROR] "
+    assert_equal @email_notifier.email_prefix, "[Dummy ERROR] "
   end
 
   test "should have default email headers overridden" do
-    assert @email_notifier.email_headers == { "X-Custom-Header" => "foobar"}
+    assert_equal @email_notifier.email_headers, { "X-Custom-Header" => "foobar"}
   end
 
   test "should have default sections overridden" do
     for section in %w(new_section request session environment backtrace)
-      assert @email_notifier.sections.include? section
+      assert_includes @email_notifier.sections, section
     end
   end
 
   test "should have default background sections" do
     for section in %w(new_bkg_section backtrace data)
-      assert @email_notifier.background_sections.include? section
+      assert_includes @email_notifier.background_sections, section
     end
   end
 
   test "should have email format by default" do
-    assert @email_notifier.email_format == :text
+    assert_equal @email_notifier.email_format, :text
   end
 
   test "should have verbose subject by default" do
-    assert @email_notifier.verbose_subject == true
+    assert @email_notifier.verbose_subject
   end
 
   test "should have normalize_subject false by default" do
-    assert @email_notifier.normalize_subject == false
+    refute @email_notifier.normalize_subject
   end
 
   test "should have delivery_method nil by default" do
-    assert @email_notifier.delivery_method == nil
+    assert_nil @email_notifier.delivery_method
   end
 
   test "should have mailer_settings nil by default" do
-    assert @email_notifier.mailer_settings == nil
+    assert_nil @email_notifier.mailer_settings
   end
 
   test "should have mailer_parent by default" do
-    assert @email_notifier.mailer_parent == 'ActionMailer::Base'
+    assert_equal @email_notifier.mailer_parent, 'ActionMailer::Base'
   end
 
   test "should have template_path by default" do
-    assert @email_notifier.template_path == 'exception_notifier'
+    assert_equal @email_notifier.template_path, 'exception_notifier'
   end
 
   test "should normalize multiple digits into one N" do
@@ -75,23 +75,23 @@ class EmailNotifierTest < ActiveSupport::TestCase
   end
 
   test "mail should be plain text and UTF-8 enconded by default" do
-    assert @mail.content_type == "text/plain; charset=UTF-8"
+    assert_equal @mail.content_type, "text/plain; charset=UTF-8"
   end
 
   test "should have raised an exception" do
-    assert_not_nil @exception
+    refute_nil @exception
   end
 
   test "should have generated a notification email" do
-    assert_not_nil @mail
+    refute_nil @mail
   end
 
   test "mail should have a from address set" do
-    assert @mail.from == ["dummynotifier@example.com"]
+    assert_equal @mail.from, ["dummynotifier@example.com"]
   end
 
   test "mail should have a to address set" do
-    assert @mail.to == ["dummyexceptions@example.com"]
+    assert_equal @mail.to, ["dummyexceptions@example.com"]
   end
 
   test "mail should have a descriptive subject" do
@@ -103,11 +103,11 @@ class EmailNotifierTest < ActiveSupport::TestCase
       # On Rails 4.1 the subject prefix has a single space.
       prefix = '[Dummy ERROR] '
     end
-    assert @mail.subject == prefix + '(ZeroDivisionError) "divided by 0"'
+    assert_equal @mail.subject, prefix + '(ZeroDivisionError) "divided by 0"'
   end
 
   test "mail should say exception was raised in background at show timestamp" do
-    assert @mail.encoded.include? "A ZeroDivisionError occurred in background at #{Time.current}"
+    assert_includes @mail.encoded, "A ZeroDivisionError occurred in background at #{Time.current}"
   end
 
   test "mail should prefix exception class with 'an' instead of 'a' when it starts with a vowel" do
@@ -118,7 +118,7 @@ class EmailNotifierTest < ActiveSupport::TestCase
       @vowel_mail = @email_notifier.create_email(@vowel_exception)
     end
 
-    assert @vowel_mail.encoded.include? "An ActiveRecord::RecordNotFound occurred in background at #{Time.current}"
+    assert_includes @vowel_mail.encoded, "An ActiveRecord::RecordNotFound occurred in background at #{Time.current}"
   end
 
   test "mail should contain backtrace in body" do
@@ -126,14 +126,14 @@ class EmailNotifierTest < ActiveSupport::TestCase
   end
 
   test "mail should contain data in body" do
-    assert @mail.encoded.include? '* data:'
-    assert @mail.encoded.include? ':payload=>"1/0"'
-    assert @mail.encoded.include? ':job=>"DivideWorkerJob"'
-    assert @mail.encoded.include? "My Custom Message"
+    assert_includes @mail.encoded, '* data:'
+    assert_includes @mail.encoded, ':payload=>"1/0"'
+    assert_includes @mail.encoded, ':job=>"DivideWorkerJob"'
+    assert_includes @mail.encoded, "My Custom Message"
   end
 
   test "mail should not contain any attachments" do
-    assert @mail.attachments == []
+    assert_equal @mail.attachments, []
   end
 
   test "should not send notification if one of ignored exceptions" do
@@ -146,7 +146,7 @@ class EmailNotifierTest < ActiveSupport::TestCase
       end
     end
 
-    assert @ignored_exception.class.inspect == "ActiveRecord::RecordNotFound"
+    assert_equal @ignored_exception.class.inspect, "ActiveRecord::RecordNotFound"
     assert_nil @ignored_mail
   end
 end

--- a/test/exception_notifier/email_notifier_test.rb
+++ b/test/exception_notifier/email_notifier_test.rb
@@ -95,7 +95,15 @@ class EmailNotifierTest < ActiveSupport::TestCase
   end
 
   test "mail should have a descriptive subject" do
-    assert @mail.subject == "[Dummy ERROR]  (ZeroDivisionError) \"divided by 0\""
+    # On Rails < 4.1 the subject prefix has two spaces before the rest of the
+    # subject content.
+    if Gem::Version.new(ActionMailer::VERSION::STRING) < Gem::Version.new('4.1')
+      prefix = '[Dummy ERROR]  '
+    else
+      # On Rails 4.1 the subject prefix has a single space.
+      prefix = '[Dummy ERROR] '
+    end
+    assert @mail.subject == prefix + '(ZeroDivisionError) "divided by 0"'
   end
 
   test "mail should say exception was raised in background at show timestamp" do

--- a/test/exception_notifier/webhook_notifier_test.rb
+++ b/test/exception_notifier/webhook_notifier_test.rb
@@ -9,11 +9,11 @@ class WebhookNotifierTest < ActiveSupport::TestCase
     webhook.stubs(:call).returns(fake_response)
     response = webhook.call(fake_exception)
 
-    assert_not_nil response
+    refute_nil response
     assert_equal response[:status], 200
     assert_equal response[:body][:exception][:error_class], "ZeroDivisionError"
-    assert response[:body][:exception][:message].include? "divided by 0"
-    assert response[:body][:exception][:backtrace].include? "/exception_notification/test/webhook_notifier_test.rb:48"
+    assert_includes response[:body][:exception][:message], "divided by 0"
+    assert_includes response[:body][:exception][:backtrace], "/exception_notification/test/webhook_notifier_test.rb:48"
     
     assert response[:body][:request][:cookies].has_key?(:cookie_item1)
     assert_equal response[:body][:request][:url], "http://example.com/example"

--- a/test/exception_notifier_test.rb
+++ b/test/exception_notifier_test.rb
@@ -2,18 +2,18 @@ require 'test_helper'
 
 class ExceptionNotifierTest < ActiveSupport::TestCase
   test "should have default ignored exceptions" do
-    assert ExceptionNotifier.ignored_exceptions == ['ActiveRecord::RecordNotFound', 'AbstractController::ActionNotFound', 'ActionController::RoutingError', 'ActionController::UnknownFormat']
+    assert_equal ExceptionNotifier.ignored_exceptions, ['ActiveRecord::RecordNotFound', 'AbstractController::ActionNotFound', 'ActionController::RoutingError', 'ActionController::UnknownFormat']
   end
 
   test "should have email notifier registered" do
-    assert ExceptionNotifier.notifiers == [:email]
+    assert_equal ExceptionNotifier.notifiers, [:email]
   end
 
   test "should have a valid email notifier" do
     @email_notifier = ExceptionNotifier.registered_exception_notifier(:email)
-    assert_not_nil @email_notifier
-    assert @email_notifier.class == ExceptionNotifier::EmailNotifier
-    assert @email_notifier.respond_to?(:call)
+    refute_nil @email_notifier
+    assert_equal @email_notifier.class, ExceptionNotifier::EmailNotifier
+    assert_respond_to @email_notifier, :call
   end
 
   test "should allow register/unregister another notifier" do
@@ -21,14 +21,14 @@ class ExceptionNotifierTest < ActiveSupport::TestCase
     proc_notifier = lambda { |exception, options| called = true }
     ExceptionNotifier.register_exception_notifier(:proc, proc_notifier)
 
-    assert ExceptionNotifier.notifiers.sort == [:email, :proc]
+    assert_equal ExceptionNotifier.notifiers.sort, [:email, :proc]
 
     exception = StandardError.new
     ExceptionNotifier.notify_exception(exception)
-    assert called == true
+    assert called
 
     ExceptionNotifier.unregister_exception_notifier(:proc)
-    assert ExceptionNotifier.notifiers == [:email]
+    assert_equal ExceptionNotifier.notifiers, [:email]
   end
 
   test "should allow select notifiers to send error to" do
@@ -40,24 +40,24 @@ class ExceptionNotifierTest < ActiveSupport::TestCase
     notifier2 = lambda { |exception, options| notifier2_calls += 1 }
     ExceptionNotifier.register_exception_notifier(:notifier2, notifier2)
 
-    assert ExceptionNotifier.notifiers.sort == [:email, :notifier1, :notifier2]
+    assert_equal ExceptionNotifier.notifiers.sort, [:email, :notifier1, :notifier2]
 
     exception = StandardError.new
     ExceptionNotifier.notify_exception(exception)
-    assert notifier1_calls == 1
-    assert notifier2_calls == 1
+    assert_equal notifier1_calls, 1
+    assert_equal notifier2_calls, 1
 
     ExceptionNotifier.notify_exception(exception, {:notifiers => :notifier1})
-    assert notifier1_calls == 2
-    assert notifier2_calls == 1
+    assert_equal notifier1_calls, 2
+    assert_equal notifier2_calls, 1
 
     ExceptionNotifier.notify_exception(exception, {:notifiers => :notifier2})
-    assert notifier1_calls == 2
-    assert notifier2_calls == 2
+    assert_equal notifier1_calls, 2
+    assert_equal notifier2_calls, 2
 
     ExceptionNotifier.unregister_exception_notifier(:notifier1)
     ExceptionNotifier.unregister_exception_notifier(:notifier2)
-    assert ExceptionNotifier.notifiers == [:email]
+    assert_equal ExceptionNotifier.notifiers, [:email]
   end
 
   test "should ignore exception if satisfies conditional ignore" do
@@ -73,11 +73,11 @@ class ExceptionNotifierTest < ActiveSupport::TestCase
     exception = StandardError.new
 
     ExceptionNotifier.notify_exception(exception, {:notifiers => :test})
-    assert notifier_calls == 1
+    assert_equal notifier_calls, 1
 
     env = "development"
     ExceptionNotifier.notify_exception(exception, {:notifiers => :test})
-    assert notifier_calls == 1
+    assert_equal notifier_calls, 1
 
     ExceptionNotifier.clear_ignore_conditions!
     ExceptionNotifier.unregister_exception_notifier(:test)
@@ -91,10 +91,10 @@ class ExceptionNotifierTest < ActiveSupport::TestCase
     exception = StandardError.new
 
     ExceptionNotifier.notify_exception(exception, {:notifiers => :test})
-    assert notifier_calls == 1
+    assert_equal notifier_calls, 1
 
     ExceptionNotifier.notify_exception(exception, {:notifiers => :test, :ignore_exceptions => 'StandardError' })
-    assert notifier_calls == 1
+    assert_equal notifier_calls, 1
 
     ExceptionNotifier.unregister_exception_notifier(:test)
   end


### PR DESCRIPTION
This PR allows the builds to succeed on Travis CI again.

The first commit drops Ruby 1.9 from Travis CI, because the latest versions of sidekiq do not support Ruby 1.9 any more.

The second commit updates email_notifier_test to deal with an ActionMailer change in Rails 4.1. In the latest versions of ActionMailer, we no longer have an extra space character between the subject prefix and the rest of the subject string.

The third commit updates the test suite to use more conventional Minitest 5 syntax. The purpose of this change is to provide more debugging output during test failures. With a bare "assert", Minitest simply prints "Failed assertion, no message given." With a helper such as "assert_equal", Minitest will print the expected value along with the given value. This provides the developer with richer context information to debug the test failure.
