### PR TITLE
Reformat slack exception notification

### DIFF
--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -1,6 +1,6 @@
 module ExceptionNotifier
   class SlackNotifier
-    include ExceptionNotifier::BacktraceCleaner
+    include BacktraceCleaner
     DEFAULT_OPTIONS = {
       username: 'Exception Notifier',
       icon_emoji: ':fire:'
@@ -12,9 +12,7 @@ module ExceptionNotifier
     end
 
     def call(exception, options = {})
-      env = options.fetch(:env, {})
-      request = (env['REQUEST_METHOD'] ? ActionDispatch::Request.new(env) : nil)
-      notifier.ping '', message_options(exception, request)
+      notifier.ping '', message_options(exception, options)
     end
 
     private
@@ -23,30 +21,39 @@ module ExceptionNotifier
       @notifier ||= Slack::Notifier.new slack_options.fetch(:webhook_url)
     end
 
-    def message_options(exception, request)
-      title = "#{request.request_method} #{request.original_url}" if request
-      options = DEFAULT_OPTIONS.merge(slack_options.slice(:channel, :username, :icon_emoji))
-      options[:attachments] = [{
-        color: 'danger',
-        title: title,
-        text: exception.message,
-        fields: attachment_fields(exception, request),
-        mrkdwn_in: %w(text title fallback fields)
-      }]
-      options
+    def extract_data_from_options(options)
+      options.fetch(:data, {}).tap do |data|
+        data.merge!(error_data_for_request(options))
+        data.merge!(error_data_for_rails)
+      end
+    end
+
+    # see https://api.slack.com/docs/formatting
+    # see https://api.slack.com/incoming-webhooks
+    def message_options(exception, opts)
+      data = extract_data_from_options(opts)
+      DEFAULT_OPTIONS.merge(slack_options).merge(opts).slice(:channel, :username, :icon_emoji).tap do |options|
+        options[:attachments] = [{
+          color: 'danger',
+          title: exception.message,
+          text: exception_backtrace(exception),
+          fallback: data_to_text(data),
+          fields: attachment_fields(data)
+        }]
+      end
+    end
+
+    def data_to_text(data)
+      data.map do |key, value|
+        [key, value].join(': ')
+      end.join("\n")
     end
 
     # see https://api.slack.com/docs/attachments
-    def attachment_fields(exception, request)
-      backtrace = clean_backtrace(exception).first(10).map { |s| "> #{s}" }.join("\n")
-      fields = [
-        attachment_field('Project', Rails.application.class.parent_name, short: true),
-        attachment_field('Environment', Rails.env, short: true),
-        attachment_field('Time', Time.zone.now.strftime('%Y-%m-%d %H:%M:%S'), short: true),
-        attachment_field('Backtrace', backtrace, short: false)
-      ]
-      fields << attachment_field('Parameters', request.filtered_parameters.map { |k, v| "> #{k}=#{v}" }.join("\n"), short: false) if request
-      fields
+    def attachment_fields(data)
+      data.map do |key, value|
+        attachment_field(key, value.to_s, short: false)
+      end
     end
 
     def attachment_field(title, value, short: false)
@@ -55,6 +62,28 @@ module ExceptionNotifier
         value: value,
         short: short
       }
+    end
+
+    def exception_backtrace(exception)
+      clean_backtrace(exception).first(10).join("\n")
+    end
+
+    def error_data_for_rails
+      return {} unless defined?(Rails)
+      {
+        'Project' => Rails.application.class.parent_name,
+        'Environment' => Rails.env
+      }
+    end
+
+    def error_data_for_request(options)
+      env = options.fetch(:env, {})
+      return {} unless env['REQUEST_METHOD']
+      request = ActionDispatch::Request.new(env)
+      request.env.fetch('exception_notifier.exception_data', {}).merge(
+        'Request Method' => request.request_method,
+        'Request URL' => request.original_url
+      )
     end
   end
 end


### PR DESCRIPTION
Supercedes this pull request: https://github.com/smartinez87/exception_notification/pull/251

Changes:
* add default options for slack configuration (username, icon)
* use slack attachments API for adding exception metadata
* add support for non-rack exceptions
* use filtered_paramters from request to avoid leaking sensitive
  information