### PR TITLE
Feature: Add a way to have a backtrace callback on all notifiers

### DIFF
--- a/lib/exception_notifier.rb
+++ b/lib/exception_notifier.rb
@@ -1,6 +1,7 @@
 require 'logger'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/module/attribute_accessors'
+require 'exception_notifier/base_notifier'
 
 module ExceptionNotifier
 

--- a/lib/exception_notifier/base_notifier.rb
+++ b/lib/exception_notifier/base_notifier.rb
@@ -1,0 +1,25 @@
+module ExceptionNotifier
+  class BaseNotifier
+    attr_accessor :base_options
+
+    def initialize(options={})
+      @base_options = options
+    end
+
+    def send_notice(exception, options, message, message_opts=nil)
+      _pre_callback(exception, options, message, message_opts)
+      result = yield(message, message_opts)
+      _post_callback(exception, options, message, message_opts)
+      result
+    end
+
+    def _pre_callback(exception, options, message, message_opts)
+      @base_options[:pre_callback].call(base_options, self, exception.backtrace, message, message_opts) if @base_options[:pre_callback].respond_to?(:call)
+    end
+
+    def _post_callback(exception, options, message, message_opts)
+      @base_options[:post_callback].call(base_options, self, exception.backtrace, message, message_opts) if @base_options[:post_callback].respond_to?(:call)
+    end
+
+  end
+end

--- a/lib/exception_notifier/campfire_notifier.rb
+++ b/lib/exception_notifier/campfire_notifier.rb
@@ -1,11 +1,12 @@
 module ExceptionNotifier
-  class CampfireNotifier
+  class CampfireNotifier < BaseNotifier
 
     attr_accessor :subdomain
     attr_accessor :token
     attr_accessor :room
 
     def initialize(options)
+      super
       begin
         subdomain = options.delete(:subdomain)
         room_name = options.delete(:room_name)
@@ -20,7 +21,9 @@ module ExceptionNotifier
       if active?
         message = "A new exception occurred: '#{exception.message}'"
         message += " on '#{exception.backtrace.first}'" if exception.backtrace
-        @room.paste message message
+        send_notice(exception, options, message) do |msg, _|
+          @room.paste msg
+        end
       end
     end
 

--- a/lib/exception_notifier/hipchat_notifier.rb
+++ b/lib/exception_notifier/hipchat_notifier.rb
@@ -1,11 +1,12 @@
 module ExceptionNotifier
-  class HipchatNotifier
+  class HipchatNotifier < BaseNotifier
 
     attr_accessor :from
     attr_accessor :room
     attr_accessor :message_options
 
     def initialize(options)
+      super
       begin
         api_token         = options.delete(:api_token)
         room_name         = options.delete(:room_name)
@@ -30,7 +31,9 @@ module ExceptionNotifier
       return if !active?
 
       message = @message_template.call(exception)
-      @room.send(@from, message, @message_options)
+      send_notice(exception, options, message, @message_options) do |msg, message_opts|
+        @room.send(@from, msg, message_opts)
+      end
     end
 
     private

--- a/lib/exception_notifier/irc_notifier.rb
+++ b/lib/exception_notifier/irc_notifier.rb
@@ -1,6 +1,7 @@
 module ExceptionNotifier
-  class IrcNotifier
+  class IrcNotifier < BaseNotifier
     def initialize(options)
+      super
       @config = OpenStruct.new
       parse_options(options)
     end
@@ -8,7 +9,11 @@ module ExceptionNotifier
     def call(exception, options={})
       message = "'#{exception.message}'"
       message += " on '#{exception.backtrace.first}'" if exception.backtrace
-      send_message([*@config.prefix, *message].join(' ')) if active?
+      if active?
+        send_notice(exception, options, message) do |msg, _|
+          send_message([*@config.prefix, *msg].join(' '))
+        end
+      end
     end
 
     def send_message(message)

--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -1,10 +1,11 @@
 module ExceptionNotifier
-  class SlackNotifier
+  class SlackNotifier < BaseNotifier
     include ExceptionNotifier::BacktraceCleaner
 
     attr_accessor :notifier
 
     def initialize(options)
+      super
       begin
         @ignore_data_if = options[:ignore_data_if]
 
@@ -22,8 +23,11 @@ module ExceptionNotifier
 
       message = enrich_message_with_data(message, options)
       message = enrich_message_with_backtrace(message, exception) if exception.backtrace
-
-      @notifier.ping(message, @message_opts) if valid?
+      if valid?
+        send_notice(exception, options, message, @message_opts) do |msg, message_opts|
+          @notifier.ping(msg, message_opts)
+        end
+      end
     end
 
     protected

--- a/test/dummy/config/environment.rb
+++ b/test/dummy/config/environment.rb
@@ -8,7 +8,9 @@ Dummy::Application.config.middleware.use ExceptionNotification::Rack,
     :exception_recipients => %w{dummyexceptions@example.com},
     :email_headers => { "X-Custom-Header" => "foobar" },
     :sections => ['new_section', 'request', 'session', 'environment', 'backtrace'],
-    :background_sections => %w(new_bkg_section backtrace data)
+    :background_sections => %w(new_bkg_section backtrace data),
+    :pre_callback => proc { |opts, notifier, backtrace, message, message_opts| message_opts[:pre_callback_called] = 1 },
+    :post_callback => proc { |opts, notifier, backtrace, message, message_opts| message_opts[:post_callback_called] = 1 }
   }
 
 # Initialize the rails application

--- a/test/exception_notifier/campfire_notifier_test.rb
+++ b/test/exception_notifier/campfire_notifier_test.rb
@@ -46,6 +46,30 @@ class CampfireNotifierTest < ActiveSupport::TestCase
     assert_nil campfire.call(fake_exception)
   end
 
+  test "should call pre/post_callback if specified" do 
+    pre_callback_called, post_callback_called = 0,0
+    Tinder::Campfire.stubs(:new).returns(Object.new)
+
+    campfire = ExceptionNotifier::CampfireNotifier.new(
+      {
+        :subdomain => 'test',
+        :token => 'test_token',
+        :room_name => 'test_room',
+        :pre_callback => proc { |opts, notifier, backtrace, message, message_opts|
+          pre_callback_called += 1
+        },
+        :post_callback => proc { |opts, notifier, backtrace, message, message_opts|
+          post_callback_called += 1
+        }
+      }
+    )
+    campfire.room = Object.new
+    campfire.room.stubs(:paste).returns(fake_notification)
+    campfire.call(fake_exception)
+    assert_equal(1, pre_callback_called)
+    assert_equal(1, post_callback_called)
+  end
+
   private
 
   def fake_notification

--- a/test/exception_notifier/email_notifier_test.rb
+++ b/test/exception_notifier/email_notifier_test.rb
@@ -13,6 +13,11 @@ class EmailNotifierTest < ActiveSupport::TestCase
     end
   end
 
+  test "should call pre/post_callback if specified" do
+    assert_equal @email_notifier.options[:pre_callback_called], 1
+    assert_equal @email_notifier.options[:post_callback_called], 1
+  end
+
   test "should have default sender address overridden" do
     assert_equal @email_notifier.sender_address, %("Dummy Notifier" <dummynotifier@example.com>)
   end

--- a/test/exception_notifier/hipchat_notifier_test.rb
+++ b/test/exception_notifier/hipchat_notifier_test.rb
@@ -16,6 +16,24 @@ class HipchatNotifierTest < ActiveSupport::TestCase
     hipchat.call(fake_exception)
   end
 
+  test "should call pre/post_callback if specified" do
+    pre_callback_called, post_callback_called = 0,0
+    options = {
+      :api_token => 'good_token',
+      :room_name => 'room_name',
+      :color     => 'yellow',
+      :pre_callback => proc { |*| pre_callback_called += 1},
+      :post_callback => proc { |*| post_callback_called += 1}
+    }
+
+    HipChat::Room.any_instance.expects(:send).with('Exception', fake_body, { :color => 'yellow' }.merge(options.except(:api_token, :room_name)))
+
+    hipchat = ExceptionNotifier::HipchatNotifier.new(options)
+    hipchat.call(fake_exception)
+    assert_equal(1, pre_callback_called)
+    assert_equal(1, post_callback_called)
+  end
+
   test "should send hipchat notification without backtrace info if properly configured" do
     options = {
       :api_token => 'good_token',

--- a/test/exception_notifier/irc_notifier_test.rb
+++ b/test/exception_notifier/irc_notifier_test.rb
@@ -16,6 +16,25 @@ class IrcNotifierTest < ActiveSupport::TestCase
     irc.call(fake_exception)
   end
 
+  test "should call pre/post_callback if specified" do
+    pre_callback_called, post_callback_called = 0,0
+
+    options = {
+      :domain => 'irc.example.com',
+      :pre_callback => proc { |*| pre_callback_called += 1},
+      :post_callback => proc { |*| post_callback_called += 1}
+    }
+
+    CarrierPigeon.expects(:send).with(has_key(:uri)) do |v|
+      /divided by 0/.match(v[:message])
+    end
+
+    irc = ExceptionNotifier::IrcNotifier.new(options)
+    irc.call(fake_exception)
+    assert_equal(1, pre_callback_called)
+    assert_equal(1, post_callback_called)
+  end
+
   test "should send irc notification without backtrace info if properly configured" do
     options = {
       :domain => 'irc.example.com'

--- a/test/exception_notifier/webhook_notifier_test.rb
+++ b/test/exception_notifier/webhook_notifier_test.rb
@@ -25,6 +25,12 @@ class WebhookNotifierTest < ActiveSupport::TestCase
     assert response[:body][:data][:extra_data].has_key?(:data_item1)
   end
 
+  test "should call pre/post_callback if specified" do
+    HTTParty.stubs(:send).returns(fake_response)
+    webhook = ExceptionNotifier::WebhookNotifier.new({:url => 'http://localhost:8000'})
+    webhook.call(fake_exception)
+  end
+
   private
 
   def fake_response

--- a/test/exception_notifier_test.rb
+++ b/test/exception_notifier_test.rb
@@ -98,4 +98,5 @@ class ExceptionNotifierTest < ActiveSupport::TestCase
 
     ExceptionNotifier.unregister_exception_notifier(:test)
   end
+
 end


### PR DESCRIPTION
At the present moment it doesn't seem possible to have a callback on the exception in order to modify the message sent.
This PR adds this feature for more flexibility (which may also help to fix #277 #251) .
I wanted to add the full exception as an attachment in Slack. So now I can do:
```ruby
  config.middleware.use ExceptionNotification::Rack,
    :slack => {
      :webhook_url => "https://hooks.slack.com/services/000",
      :channel => "#dev",
      :backtrace_callback => proc { |opts, notifier, backtrace, message_opts|
        (message_opts[:attachments] ||= []) << { text: "#{backtrace.join("\n")}", color: 'danger' }
      }
  }
```

I also made a BaseNotifier class which all notifiers inherit from in order to share code between all the notifiers.

Problems:
The EmailNotifier right now is very different from the other notifiers and inherit from a Struct. So it can't inherit from my `BaseNotifier` for now. Is there a reason why you inherit from that Struct?

PS: I only added a test for the SlackNotifier for now. Because I first want to hear your point of view on this. If you are ok with the idea I'll write the other tests.