### PR TITLE
Fix incompatible character encodings error

### DIFF
--- a/lib/exception_notifier/email_notifier.rb
+++ b/lib/exception_notifier/email_notifier.rb
@@ -80,6 +80,12 @@ module ExceptionNotifier
             end
           end
 
+          helper_method :safe_encode
+
+          def safe_encode(value)
+            value.encode("utf-8", invalid: :replace, undef: :replace, replace: "_")
+          end
+
           def html_mail?
             @options[:email_format] == :html
           end

--- a/lib/exception_notifier/views/exception_notifier/_environment.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/_environment.text.erb
@@ -1,5 +1,5 @@
 <% filtered_env = @request.filtered_env -%>
 <% max = filtered_env.keys.map(&:to_s).max { |a, b| a.length <=> b.length } -%>
 <% filtered_env.keys.map(&:to_s).sort.each do |key| -%>
-* <%= raw("%-*s: %s" % [max.length, key, inspect_object(filtered_env[key])]) %>
+* <%= raw safe_encode("%-*s: %s" % [max.length, key, inspect_object(filtered_env[key])]) %>
 <% end -%>

--- a/lib/exception_notifier/views/exception_notifier/_request.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/_request.text.erb
@@ -1,7 +1,7 @@
-* URL        : <%= raw @request.url %>
+* URL        : <%= raw safe_encode @request.url %>
 * HTTP Method: <%= raw @request.request_method %>
 * IP address : <%= raw @request.remote_ip %>
-* Parameters : <%= raw @request.filtered_parameters.inspect %>
+* Parameters : <%= raw safe_encode @request.filtered_parameters.inspect %>
 * Timestamp  : <%= raw Time.current %>
 * Server : <%= raw Socket.gethostname %>
 <% if defined?(Rails) && Rails.respond_to?(:root) %>

--- a/test/exception_notifier/email_notifier_test.rb
+++ b/test/exception_notifier/email_notifier_test.rb
@@ -155,6 +155,26 @@ class EmailNotifierTest < ActiveSupport::TestCase
     assert_nil @ignored_mail
   end
 
+  test "should encode environment strings" do
+    email_notifier = ExceptionNotifier::EmailNotifier.new(
+      :sender_address => "<dummynotifier@example.com>",
+      :exception_recipients => %w{dummyexceptions@example.com},
+      :deliver_with => :deliver_now
+    )
+
+    mail = email_notifier.create_email(
+      @exception,
+      :env => {
+        "REQUEST_METHOD" => "GET",
+        "rack.input" => "",
+        "invalid_encoding" => "R\xC3\xA9sum\xC3\xA9".force_encoding(Encoding::ASCII),
+      },
+      :email_format => :text
+    )
+
+    assert_match /invalid_encoding\s+: R__sum__/, mail.encoded
+  end
+
   if defined?(Rails) && ('4.2'...'5.0').cover?(Rails.version)
     test "should be able to specify ActionMailer::MessageDelivery method" do
       email_notifier = ExceptionNotifier::EmailNotifier.new(


### PR DESCRIPTION
When generating the summary of an exception, some env information can
contain an invalid character encoding resulting in a "Incompatible
character encodings" error.

In order to avoid this we need to encode these strings into valid UTF-8
strings.