### PR TITLE
HTML-escape exception messages sent to hipchat

### DIFF
--- a/lib/exception_notifier/hipchat_notifier.rb
+++ b/lib/exception_notifier/hipchat_notifier.rb
@@ -16,7 +16,7 @@ module ExceptionNotifier
         @from             = options.delete(:from) || 'Exception'
         @room             = HipChat::Client.new(api_token, opts)[room_name]
         @message_template = options.delete(:message_template) || ->(exception) {
-          msg = "A new exception occurred: '#{exception.message}'"
+          msg = "A new exception occurred: '#{Rack::Utils.escape_html(exception.message)}'"
           msg += " on '#{exception.backtrace.first}'" if exception.backtrace
           msg
         }


### PR DESCRIPTION
ones that use the default message_template, at least

We're seeing exception messages that mention an object, for example `#<File:foobar>`, and everything after the `#` isn't visible in hipchat.  I didn't escape the backtrace line since that would involve changing a lot more tests, and you'd have to have gt/lt chars in your file path to cause a problem, which isn't likely.