### PR TITLE
hotfix: Send the correct options in send_notice

### DIFF
--- a/lib/exception_notifier/base_notifier.rb
+++ b/lib/exception_notifier/base_notifier.rb
@@ -14,11 +14,11 @@ module ExceptionNotifier
     end
 
     def _pre_callback(exception, options, message, message_opts)
-      @base_options[:pre_callback].call(base_options, self, exception.backtrace, message, message_opts) if @base_options[:pre_callback].respond_to?(:call)
+      @base_options[:pre_callback].call(options, self, exception.backtrace, message, message_opts) if @base_options[:pre_callback].respond_to?(:call)
     end
 
     def _post_callback(exception, options, message, message_opts)
-      @base_options[:post_callback].call(base_options, self, exception.backtrace, message, message_opts) if @base_options[:post_callback].respond_to?(:call)
+      @base_options[:post_callback].call(options, self, exception.backtrace, message, message_opts) if @base_options[:post_callback].respond_to?(:call)
     end
 
   end


### PR DESCRIPTION
Looks like the wrong options were passed to the callbacks. base_options instead of options. This PR fixes that.