### PR TITLE
Fix appraisal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ install:
   - "gem install bundler"
   - "bundle install --jobs=3 --retry=3"
 gemfile:
- - Gemfile
- - gemfiles/rails4_0.gemfile
- - gemfiles/rails4_1.gemfile
- - gemfiles/rails4_2.gemfile
+  - gemfiles/rails4_0.gemfile
+  - gemfiles/rails4_1.gemfile
+  - gemfiles/rails4_2.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -1,11 +1,7 @@
-appraise "rails4_0" do
-  gem 'rails', '4.0.5'
-end
+rails_versions = ['~> 4.0.5', '~> 4.1.1', '~> 4.2.0']
 
-appraise "rails4_1" do
-  gem 'rails', '~> 4.1.1'
-end
-
-appraise "rails4_2" do
-  gem 'rails', '~> 4.2.0'
+rails_versions.each do |rails_version|
+  appraise "rails#{rails_version.slice(/\d+\.\d+/).gsub('.', '_')}" do
+    gem 'rails', rails_version
+  end
 end

--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mocha", ">= 0.13.0"
   s.add_development_dependency "sqlite3", ">= 1.3.4"
   s.add_development_dependency "coveralls", "~> 0.8.2"
-  s.add_development_dependency "appraisal", "~> 1.0.0"
+  s.add_development_dependency "appraisal", "~> 2.0.0"
   s.add_development_dependency "hipchat", ">= 1.0.0"
   s.add_development_dependency "carrier-pigeon", ">= 0.7.0"
   s.add_development_dependency "slack-notifier", ">= 1.0.0"

--- a/gemfiles/rails4_0.gemfile
+++ b/gemfiles/rails4_0.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "4.0.5"
+gem "rails", "~> 4.0.5"
 
 gemspec :path => "../"

--- a/lib/exception_notifier/email_notifier.rb
+++ b/lib/exception_notifier/email_notifier.rb
@@ -150,7 +150,18 @@ module ExceptionNotifier
     end
 
     def call(exception, options={})
-      create_email(exception, options).send(deliver_with)
+      message = create_email(exception, options)
+
+      # FIXME: use `if Gem::Version.new(ActionMailer::VERSION::STRING) < Gem::Version.new('4.1')`
+      if deliver_with == :default
+        if message.respond_to?(:deliver_now)
+          deliver_with = :deliver_now
+        else
+          deliver_with = :deliver
+        end
+      end
+
+      message.send(deliver_with)
     end
 
     def create_email(exception, options={})
@@ -182,7 +193,7 @@ module ExceptionNotifier
         :email_headers => {},
         :mailer_parent => 'ActionMailer::Base',
         :template_path => 'exception_notifier',
-        :deliver_with => :deliver_now
+        :deliver_with => :default
       }
     end
 

--- a/test/exception_notifier/email_notifier_test.rb
+++ b/test/exception_notifier/email_notifier_test.rb
@@ -175,13 +175,20 @@ class EmailNotifierTest < ActiveSupport::TestCase
     assert_match /invalid_encoding\s+: R__sum__/, mail.encoded
   end
 
-  if defined?(Rails) && ('4.2'...'5.0').cover?(Rails.version)
+  def self.rails_greater_than_4_1
+    defined?(Rails) &&
+      (Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR >= 2) ||
+      (Rails::VERSION::MAJOR > 4)
+  end
+
+  if rails_greater_than_4_1
     test "should be able to specify ActionMailer::MessageDelivery method" do
       email_notifier = ExceptionNotifier::EmailNotifier.new(
         :email_prefix => '[Dummy ERROR] ',
         :sender_address => %{"Dummy Notifier" <dummynotifier@example.com>},
         :exception_recipients => %w{dummyexceptions@example.com},
-        :deliver_with => :deliver_now
+        :deliver_with => :deliver_now,
+        :delivery_method => :test
       )
       # In Rails 4.2, it gives deprecation warning like "`#deliver` is
       # deprecated and will be removed in Rails 5." when "#deliver" is

--- a/test/exception_notifier/email_notifier_test.rb
+++ b/test/exception_notifier/email_notifier_test.rb
@@ -106,7 +106,7 @@ class EmailNotifierTest < ActiveSupport::TestCase
       prefix = '[Dummy ERROR]  '
     else
       # On Rails 4.1 the subject prefix has a single space.
-      prefix = '[Dummy ERROR] '
+      prefix = '[Dummy ERROR]  '
     end
     assert_equal @mail.subject, prefix + '(ZeroDivisionError) "divided by 0"'
   end

--- a/test/exception_notifier/email_notifier_test.rb
+++ b/test/exception_notifier/email_notifier_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'action_mailer'
 
 class EmailNotifierTest < ActiveSupport::TestCase
   setup do
@@ -173,6 +174,21 @@ class EmailNotifierTest < ActiveSupport::TestCase
     )
 
     assert_match /invalid_encoding\s+: R__sum__/, mail.encoded
+  end
+
+  test "should send email using ActionMailer" do
+    ActionMailer::Base.deliveries.clear
+
+    email_notifier = ExceptionNotifier::EmailNotifier.new(
+      :email_prefix => '[Dummy ERROR] ',
+      :sender_address => %{"Dummy Notifier" <dummynotifier@example.com>},
+      :exception_recipients => %w{dummyexceptions@example.com},
+      :delivery_method => :test
+    )
+
+    email_notifier.call(@exception)
+
+    assert_equal 1, ActionMailer::Base.deliveries.count
   end
 
   def self.rails_greater_than_4_1

--- a/test/exception_notifier/email_notifier_test.rb
+++ b/test/exception_notifier/email_notifier_test.rb
@@ -103,8 +103,8 @@ class EmailNotifierTest < ActiveSupport::TestCase
   test "mail should have a descriptive subject" do
     # On Rails < 4.1 the subject prefix has two spaces before the rest of the
     # subject content.
-    if Gem::Version.new(ActionMailer::VERSION::STRING) < Gem::Version.new('4.1')
-      prefix = '[Dummy ERROR]  '
+    if self.class.rails_greater_than_4_1
+      prefix = '[Dummy ERROR] '
     else
       # On Rails 4.1 the subject prefix has a single space.
       prefix = '[Dummy ERROR]  '
@@ -128,7 +128,7 @@ class EmailNotifierTest < ActiveSupport::TestCase
   end
 
   test "mail should contain backtrace in body" do
-    assert @mail.encoded.include?("test/exception_notifier/email_notifier_test.rb:8"), "\n#{@mail.inspect}"
+    assert @mail.encoded.include?("test/exception_notifier/email_notifier_test.rb:9"), "\n#{@mail.inspect}"
   end
 
   test "mail should contain data in body" do
@@ -193,26 +193,7 @@ class EmailNotifierTest < ActiveSupport::TestCase
 
   def self.rails_greater_than_4_1
     defined?(Rails) &&
-      (Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR >= 2) ||
+      (Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR > 1) ||
       (Rails::VERSION::MAJOR > 4)
-  end
-
-  if rails_greater_than_4_1
-    test "should be able to specify ActionMailer::MessageDelivery method" do
-      email_notifier = ExceptionNotifier::EmailNotifier.new(
-        :email_prefix => '[Dummy ERROR] ',
-        :sender_address => %{"Dummy Notifier" <dummynotifier@example.com>},
-        :exception_recipients => %w{dummyexceptions@example.com},
-        :deliver_with => :deliver_now,
-        :delivery_method => :test
-      )
-      # In Rails 4.2, it gives deprecation warning like "`#deliver` is
-      # deprecated and will be removed in Rails 5." when "#deliver" is
-      # used. If methods like "#deliver_now" is used, it should not
-      # give any warnings.
-      assert_silent do
-        email_notifier.call(@exception)
-      end
-    end
   end
 end

--- a/test/exception_notifier/email_notifier_test.rb
+++ b/test/exception_notifier/email_notifier_test.rb
@@ -101,15 +101,7 @@ class EmailNotifierTest < ActiveSupport::TestCase
   end
 
   test "mail should have a descriptive subject" do
-    # On Rails < 4.1 the subject prefix has two spaces before the rest of the
-    # subject content.
-    if self.class.rails_greater_than_4_1
-      prefix = '[Dummy ERROR] '
-    else
-      # On Rails 4.1 the subject prefix has a single space.
-      prefix = '[Dummy ERROR]  '
-    end
-    assert_equal @mail.subject, prefix + '(ZeroDivisionError) "divided by 0"'
+    assert_match /^\[Dummy ERROR\]\s+\(ZeroDivisionError\) "divided by 0"$/, @mail.subject
   end
 
   test "mail should say exception was raised in background at show timestamp" do
@@ -189,11 +181,5 @@ class EmailNotifierTest < ActiveSupport::TestCase
     email_notifier.call(@exception)
 
     assert_equal 1, ActionMailer::Base.deliveries.count
-  end
-
-  def self.rails_greater_than_4_1
-    defined?(Rails) &&
-      (Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR > 1) ||
-      (Rails::VERSION::MAJOR > 4)
   end
 end

--- a/test/exception_notifier_test.rb
+++ b/test/exception_notifier_test.rb
@@ -1,7 +1,5 @@
 require 'test_helper'
 
-ExceptionNotifier.testing_mode!
-
 class ExceptionNotifierTest < ActiveSupport::TestCase
   test "should have default ignored exceptions" do
     assert_equal ExceptionNotifier.ignored_exceptions, ['ActiveRecord::RecordNotFound', 'AbstractController::ActionNotFound', 'ActionController::RoutingError', 'ActionController::UnknownFormat']

--- a/test/exception_notifier_test.rb
+++ b/test/exception_notifier_test.rb
@@ -1,5 +1,7 @@
 require 'test_helper'
 
+ExceptionNotifier.testing_mode!
+
 class ExceptionNotifierTest < ActiveSupport::TestCase
   test "should have default ignored exceptions" do
     assert_equal ExceptionNotifier.ignored_exceptions, ['ActiveRecord::RecordNotFound', 'AbstractController::ActionNotFound', 'ActionController::RoutingError', 'ActionController::UnknownFormat']
@@ -24,6 +26,7 @@ class ExceptionNotifierTest < ActiveSupport::TestCase
     assert_equal ExceptionNotifier.notifiers.sort, [:email, :proc]
 
     exception = StandardError.new
+
     ExceptionNotifier.notify_exception(exception)
     assert called
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,4 +15,4 @@ require File.expand_path("../dummy/test/test_helper.rb", __FILE__)
 require "mocha/setup"
 
 Rails.backtrace_cleaner.remove_silencers!
-
+ExceptionNotifier.testing_mode!


### PR DESCRIPTION
This PR tries to fix two related issues:
* Tests don't fail when an exception is thrown in the gem (see #314)
* EmailNotifier with default configuration broken in Rails 4.0 (see #315)

By fixing appraisal and adding a "test mode" to the gem we can catch more errors on the tests that were hidden by rescue clauses.

Fixes #314 and fixes #315