### PR TITLE
Send the entire backtrace to Slack

### DIFF
--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -29,7 +29,7 @@ module ExceptionNotifier
       fields.push({ title: 'Hostname', value: Socket.gethostname })
 
       if exception.backtrace
-        formatted_backtrace = "```#{exception.backtrace.first(5).join("\n")}```"
+        formatted_backtrace = "```#{exception.backtrace.join("\n")}```"
         fields.push({ title: 'Backtrace', value: formatted_backtrace })
       end
 

--- a/test/exception_notifier/slack_notifier_test.rb
+++ b/test/exception_notifier/slack_notifier_test.rb
@@ -5,7 +5,7 @@ class SlackNotifierTest < ActiveSupport::TestCase
 
   def setup
     @exception = fake_exception
-    @exception.stubs(:backtrace).returns(["backtrace line 1", "backtrace line 2"])
+    @exception.stubs(:backtrace).returns(fake_backtrace)
     @exception.stubs(:message).returns('exception message')
     Socket.stubs(:gethostname).returns('example.com')
   end
@@ -131,7 +131,7 @@ class SlackNotifierTest < ActiveSupport::TestCase
     Slack::Notifier.any_instance.expects(:ping).with('',
                                                      {:icon_url => 'icon',
                                                       :attachments => [
-                                                        {:text => "backtrace line 1\nbacktrace line 2",
+                                                        {:text => fake_backtrace.join("\n"),
                                                          :color => 'danger'}
                                                      ]})
 
@@ -154,12 +154,23 @@ class SlackNotifierTest < ActiveSupport::TestCase
     StandardError.new('my custom error')
   end
 
+  def fake_backtrace
+    [
+      "backtrace line 1",
+      "backtrace line 2",
+      "backtrace line 3",
+      "backtrace line 4",
+      "backtrace line 5",
+      "backtrace line 6",
+    ]
+  end
+
   def fake_notification(exception = @exception, data_string = nil)
     text = "*An exception occurred while doing*: ` <>`\n"
 
     fields = [ { title: 'Exception', value: exception.message} ]
     fields.push({ title: 'Hostname', value: 'example.com' })
-    fields.push({ title: 'Backtrace', value: "```backtrace line 1\nbacktrace line 2```" }) if exception.backtrace
+    fields.push({ title: 'Backtrace', value: "```#{fake_backtrace.join("\n")}```" }) if exception.backtrace
     fields.push({ title: 'Data', value: "```#{data_string}```" }) if data_string
 
     { attachments: [ color: 'danger', text: text, fields: fields, mrkdwn_in: %w(text fields) ] }


### PR DESCRIPTION
For a typical Rails app, sending `first(5)` shows only internal Rails code, for example:

```
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/inflector/methods.rb:261:in `const_get'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/inflector/methods.rb:261:in `block in constantize'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/inflector/methods.rb:259:in `each'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/inflector/methods.rb:259:in `inject'
/app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/inflector/methods.rb:259:in `constantine'
```

I'd prefer to see the entire backtrack, but if this isn't acceptable, perhaps we can use `last(5)` instead or make it customizable as in #313.