### PR TITLE
Make backtrace cleaning optional

### DIFF
--- a/lib/exception_notification/rack.rb
+++ b/lib/exception_notification/rack.rb
@@ -6,6 +6,7 @@ module ExceptionNotification
       @app = app
 
       ExceptionNotifier.ignored_exceptions = options.delete(:ignore_exceptions) if options.key?(:ignore_exceptions)
+      ExceptionNotifier.clean_backtrace = options.delete(:clean_backtrace) if options.key?(:clean_backtrace)
 
       if options.key?(:ignore_if)
         rack_ignore = options.delete(:ignore_if)

--- a/lib/exception_notifier.rb
+++ b/lib/exception_notifier.rb
@@ -28,6 +28,9 @@ module ExceptionNotifier
   mattr_accessor :testing_mode
   @@testing_mode = false
 
+  mattr_accessor :clean_backtrace
+  @@clean_backtrace = true
+
   class << self
     # Store conditions that decide when exceptions must be ignored or not.
     @@ignores = []

--- a/lib/exception_notifier/email_notifier.rb
+++ b/lib/exception_notifier/email_notifier.rb
@@ -45,7 +45,7 @@ module ExceptionNotifier
 
             @exception = exception
             @options   = options.reverse_merge(default_options)
-            @backtrace = exception.backtrace || []
+            @backtrace = exception.backtrace ? clean_backtrace(exception) : []
             @sections  = @options[:background_sections]
             @data      = options[:data] || {}
 

--- a/lib/exception_notifier/modules/backtrace_cleaner.rb
+++ b/lib/exception_notifier/modules/backtrace_cleaner.rb
@@ -2,7 +2,8 @@ module ExceptionNotifier
   module BacktraceCleaner
 
     def clean_backtrace(exception)
-      if defined?(Rails) && Rails.respond_to?(:backtrace_cleaner)
+
+      if ExceptionNotifier.clean_backtrace && defined?(Rails) && Rails.respond_to?(:backtrace_cleaner)
         Rails.backtrace_cleaner.send(:filter, exception.backtrace)
       else
         exception.backtrace


### PR DESCRIPTION
This is a new take of the previous https://github.com/smartinez87/exception_notification/pull/242 pull request by @chancancode. 

I borrowed the tests and adapted the implementation he wrote at the time to work with the current gem's code.

**But**, to make the tests pass, I had to add the ability to clean the backtracke to the `#background_exception_notification` since the EmailNotifier tests are written with the background notification.

This seems bad to me, since we wouldn't have the ability to disable backtrace cleaning only for the controller-exception backed email notifier.

Which way should I go ? Write a separate test class to test the exception with a controller exception ?

This brings be to think about the whole backtrace cleaning strategy, is it really useful ? Can't we just, in the HTML e-mail, differenciate app and gem backtrace lines ?

Thanks for your feedback !