### PR TITLE
Allow exception_recipients to be a proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ Who the message is from.
 
 ##### exception_recipients
 
-*String/Array of strings, default: []*
+*String/Array of strings/Proc, default: []*
 
-Who the message is destined for, can be a string of addresses, or an array of addresses.
+Who the message is destined for, can be a string of addresses, an array of addresses, or it can be a proc that returns a string of addresses or an array of addresses. The proc will be evaluated when the mail is sent.
 
 ##### email_prefix
 

--- a/lib/exception_notifier/email_notifier.rb
+++ b/lib/exception_notifier/email_notifier.rb
@@ -94,10 +94,11 @@ module ExceptionNotifier
             set_data_variables
             subject = compose_subject
             name = @env.nil? ? 'background_exception_notification' : 'exception_notification'
+            exception_recipients = maybe_call(@options[:exception_recipients])
 
             headers = {
               :delivery_method => @options[:delivery_method],
-              :to => @options[:exception_recipients],
+              :to => exception_recipients,
               :from => @options[:sender_address],
               :subject => subject,
               :template_name => name
@@ -117,6 +118,10 @@ module ExceptionNotifier
             if defined?(Rails) && Rails.respond_to?(:root)
               self.prepend_view_path Rails.root.nil? ? "app/views" : "#{Rails.root}/app/views"
             end
+          end
+
+          def maybe_call(maybe_proc)
+            maybe_proc.respond_to?(:call) ? maybe_proc.call : maybe_proc
           end
         end
       end

--- a/test/exception_notifier/email_notifier_test.rb
+++ b/test/exception_notifier/email_notifier_test.rb
@@ -182,4 +182,19 @@ class EmailNotifierTest < ActiveSupport::TestCase
 
     assert_equal 1, ActionMailer::Base.deliveries.count
   end
+
+  test "should lazily evaluate exception_recipients" do
+    exception_recipients = %w{first@example.com second@example.com}
+    email_notifier = ExceptionNotifier::EmailNotifier.new(
+      :email_prefix => '[Dummy ERROR] ',
+      :sender_address => %{"Dummy Notifier" <dummynotifier@example.com>},
+      :exception_recipients => -> { [ exception_recipients.shift ] },
+      :delivery_method => :test
+    )
+
+    mail = email_notifier.call(@exception)
+    assert_equal %w{first@example.com}, mail.to
+    mail = email_notifier.call(@exception)
+    assert_equal %w{second@example.com}, mail.to
+  end
 end


### PR DESCRIPTION
This is an attempt at allowing `exception_recipients` to be determined at runtime. It simply checks if `exception_recipients` is callable and then calls it. 

Issue #191 