### PR TITLE
Remove dependency on Rails

### DIFF
--- a/lib/exception_notifier/views/exception_notifier/_request.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/_request.html.erb
@@ -17,7 +17,7 @@
   </li>
   <li>
     <strong>Timestamp:</strong>
-    <span><%= Time.current %></span>
+    <span><%= Time.now %></span>
   </li>
   <li>
     <strong>Server:</strong>

--- a/lib/exception_notifier/views/exception_notifier/_request.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/_request.text.erb
@@ -2,7 +2,7 @@
 * HTTP Method: <%= raw @request.request_method %>
 * IP address : <%= raw @request.remote_ip %>
 * Parameters : <%= raw safe_encode @request.filtered_parameters.inspect %>
-* Timestamp  : <%= raw Time.current %>
+* Timestamp  : <%= raw Time.now %>
 * Server : <%= raw Socket.gethostname %>
 <% if defined?(Rails) && Rails.respond_to?(:root) %>
 * Rails root : <%= raw Rails.root %>

--- a/lib/exception_notifier/views/exception_notifier/background_exception_notification.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/background_exception_notification.html.erb
@@ -30,7 +30,7 @@
       <tr>
         <td style="padding: 10px; border: 1px solid #eed3d7; background-color: #f2dede">
           <h3 style="color: #b94a48">
-            <%= @exception.class.to_s =~ /^[aeiou]/i ? 'An' : 'A' %> <%= @exception.class %> occurred in background at <%= Time.current %> :
+            <%= @exception.class.to_s =~ /^[aeiou]/i ? 'An' : 'A' %> <%= @exception.class %> occurred in background at <%= Time.now %> :
           </h3>
           <p style="color: #b94a48"><%= @exception.message %></p>
           <pre style="font-size: 12px; padding: 5px; background-color:#f5f5f5">

--- a/lib/exception_notifier/views/exception_notifier/background_exception_notification.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/background_exception_notification.text.erb
@@ -1,4 +1,4 @@
-<%= @exception.class.to_s =~ /^[aeiou]/i ? 'An' : 'A' %> <%= @exception.class %> occurred in background at <%= raw Time.current %> :
+<%= @exception.class.to_s =~ /^[aeiou]/i ? 'An' : 'A' %> <%= @exception.class %> occurred in background at <%= raw Time.now %> :
 
   <%= @exception.message %>
   <%= @backtrace.first %>

--- a/test/dummy/test/functional/posts_controller_test.rb
+++ b/test/dummy/test/functional/posts_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class PostsControllerTest < ActionController::TestCase
   setup do
-    Time.stubs(:current).returns('Sat, 20 Apr 2013 20:58:55 UTC +00:00')
+    Time.stubs(:now).returns(Time.new(2013, 4, 20, 20, 58, 55, 0))
     @email_notifier = ExceptionNotifier.registered_exception_notifier(:email)
     begin
       @post = posts(:one)
@@ -46,7 +46,7 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   test "mail should contain timestamp of exception in body" do
-    assert_includes @mail.encoded, "Timestamp  : #{Time.current}"
+    assert_includes @mail.encoded, "Timestamp  : #{Time.now}"
   end
 
   test "mail should contain the newly defined section" do

--- a/test/exception_notifier/email_notifier_test.rb
+++ b/test/exception_notifier/email_notifier_test.rb
@@ -105,7 +105,7 @@ class EmailNotifierTest < ActiveSupport::TestCase
   end
 
   test "mail should say exception was raised in background at show timestamp" do
-    assert_includes @mail.encoded, "A ZeroDivisionError occurred in background at #{Time.current}"
+    assert_includes @mail.encoded, "A ZeroDivisionError occurred in background at #{Time.now}"
   end
 
   test "mail should prefix exception class with 'an' instead of 'a' when it starts with a vowel" do
@@ -116,7 +116,7 @@ class EmailNotifierTest < ActiveSupport::TestCase
       @vowel_mail = @email_notifier.create_email(@vowel_exception)
     end
 
-    assert_includes @vowel_mail.encoded, "An ActiveRecord::RecordNotFound occurred in background at #{Time.current}"
+    assert_includes @vowel_mail.encoded, "An ActiveRecord::RecordNotFound occurred in background at #{Time.now}"
   end
 
   test "mail should contain backtrace in body" do


### PR DESCRIPTION
This gem does not work well with Sinatra (despite description in the readme),
because email templates use [Time.current][1] call that is available only in
active support.

This PR removes the dependency by using Time.now instead.

[1]: http://apidock.com/rails/v4.1.8/Time/current/class