### PR TITLE
Mattermost: fix backtrace dump size

### DIFF
--- a/lib/exception_notifier/mattermost_notifier.rb
+++ b/lib/exception_notifier/mattermost_notifier.rb
@@ -111,6 +111,7 @@ module ExceptionNotifier
       def message_backtrace(size = 3)
         text = []
 
+        size = @backtrace.size < size ? @backtrace.size : size
         text << "### Backtrace"
         text << "```"
         size.times { |i| text << "* " + @backtrace[i] }


### PR DESCRIPTION
[117]

Hi there,

Quick fix for backtrace max dump size, sorry for inconvenience