### PR TITLE
Added option for backtrace line with default full backtrace

### DIFF
--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -8,6 +8,7 @@ module ExceptionNotifier
       super
       begin
         @ignore_data_if = options[:ignore_data_if]
+        @backtrace_lines = options[:backtrace_lines]
 
         webhook_url = options.fetch(:webhook_url)
         @message_opts = options.fetch(:additional_parameters, {})
@@ -40,7 +41,7 @@ module ExceptionNotifier
       fields.push({ title: 'Hostname', value: Socket.gethostname })
 
       if exception.backtrace
-        formatted_backtrace = "```#{exception.backtrace.join("\n")}```"
+        formatted_backtrace = @backtrace_lines ? "```#{exception.backtrace.first(@backtrace_lines).join("\n")}```" : "```#{exception.backtrace.join("\n")}```"
         fields.push({ title: 'Backtrace', value: formatted_backtrace })
       end
 

--- a/test/exception_notifier/slack_notifier_test.rb
+++ b/test/exception_notifier/slack_notifier_test.rb
@@ -60,6 +60,18 @@ class SlackNotifierTest < ActiveSupport::TestCase
     assert_equal slack_notifier.notifier.username, options[:username]
   end
 
+  test "should send the notification with specific backtrace lines" do
+    options = {
+      webhook_url: "http://slack.webhook.url",
+      backtrace_lines: 1
+    }
+
+    Slack::Notifier.any_instance.expects(:ping).with('', fake_notification(@exception, nil, 1))
+
+    slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
+    slack_notifier.call(@exception)
+  end
+
   test "should pass the additional parameters to Slack::Notifier.ping" do
     options = {
       webhook_url: "http://slack.webhook.url",
@@ -165,7 +177,7 @@ class SlackNotifierTest < ActiveSupport::TestCase
     ]
   end
 
-  def fake_notification(exception = @exception, notification_options = {}, data_string = nil)
+  def fake_notification(exception = @exception, notification_options = {}, data_string = nil, expected_backtrace_lines = nil)
     exception_name = "*#{exception.class.to_s =~ /^[aeiou]/i ? 'An' : 'A'}* `#{exception.class.to_s}`"
     if notification_options[:env].nil?
       text = "#{exception_name} *occured in background*"
@@ -183,7 +195,10 @@ class SlackNotifierTest < ActiveSupport::TestCase
 
     fields = [ { title: 'Exception', value: exception.message} ]
     fields.push({ title: 'Hostname', value: 'example.com' })
-    fields.push({ title: 'Backtrace', value: "```#{fake_backtrace.join("\n")}```" }) if exception.backtrace
+    if exception.backtrace
+      formatted_backtrace = expected_backtrace_lines ? "```#{exception.backtrace.first(expected_backtrace_lines).join("\n")}```" : "```#{exception.backtrace.join("\n")}```"
+      fields.push({ title: 'Backtrace', value: formatted_backtrace })
+    end
     fields.push({ title: 'Data', value: "```#{data_string}```" }) if data_string
 
     { attachments: [ color: 'danger', text: text, fields: fields, mrkdwn_in: %w(text fields) ] }

--- a/test/exception_notifier/slack_notifier_test.rb
+++ b/test/exception_notifier/slack_notifier_test.rb
@@ -66,7 +66,7 @@ class SlackNotifierTest < ActiveSupport::TestCase
       backtrace_lines: 1
     }
 
-    Slack::Notifier.any_instance.expects(:ping).with('', fake_notification(@exception, nil, 1))
+    Slack::Notifier.any_instance.expects(:ping).with('', fake_notification(@exception, {}, nil, 1))
 
     slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
     slack_notifier.call(@exception)


### PR DESCRIPTION
This is a rebased version of #313. I simply rebased this and made no assumptions about code style, left whitespace as-is etc.

See https://github.com/smartinez87/exception_notification/pull/313#issuecomment-232612645

Fixes #313