### PR TITLE
Re-use Rail's ActionDispatch ParameterFilter to filter sensitive information in the data and session sections

### DIFF
--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'exception_notification'
-  s.version = '4.2.1'
+  s.version = '4.2.2'
   s.authors = ["Jamis Buck", "Josh Peek"]
   s.date = %q{2016-07-17}
   s.summary = "Exception notification for Rails apps"

--- a/lib/exception_notifier/views/exception_notifier/_data.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/_data.html.erb
@@ -1,6 +1,6 @@
 <ul style="list-style: none">
   <li>
     <strong>data:</strong>
-    <span><%= PP.pp(@data, "") %></span>
+    <span><%= PP.pp(ActionDispatch::Http::ParameterFilter.new(Rails.application.config.filter_parameters).filter(@data), "") %></span>
   </li>
 </ul>

--- a/lib/exception_notifier/views/exception_notifier/_data.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/_data.text.erb
@@ -1,1 +1,1 @@
-* data: <%= raw PP.pp(@data, "") %>
+* data: <%= raw PP.pp(ActionDispatch::Http::ParameterFilter.new(Rails.application.config.filter_parameters).filter(@data), "") %>

--- a/lib/exception_notifier/views/exception_notifier/_session.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/_session.html.erb
@@ -5,6 +5,6 @@
   </li>
   <li>
     <strong>data: </strong>
-    <span><%= PP.pp(@request.session.to_hash, "") %></span>
+    <span><%= PP.pp(ActionDispatch::Http::ParameterFilter.new(Rails.application.config.filter_parameters).filter(@request.session.to_hash), "") %></span>
   </li>
 </ul>

--- a/lib/exception_notifier/views/exception_notifier/_session.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/_session.text.erb
@@ -1,2 +1,2 @@
 * session id: <%= @request.ssl? ? "[FILTERED]" : (raw (@request.session['session_id'] || (@request.env["rack.session.options"] and @request.env["rack.session.options"][:id])).inspect.html_safe) %>
-* data: <%= raw PP.pp(@request.session.to_hash, "") %>
+* data: <%= raw PP.pp(ActionDispatch::Http::ParameterFilter.new(Rails.application.config.filter_parameters).filter(@request.session.to_hash), "") %>


### PR DESCRIPTION
Re-use Rail's ActionDispatch ParameterFilter to filter sensitive information in the data and session sections such as session_id from the session (request) and data sections of the notifications are not leaked.