### PR TITLE
added :include_controller_and_action_names_in_subject as option for EmailNotifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,12 @@ If enabled, include the exception message in the subject. Use `:verbose_subject 
 
 If enabled, remove numbers from subject so they thread as a single one. Use `:normalize_subject => true` to enable it.
 
+##### include_controller_and_action_names_in_subject
+
+*Boolean, default: true*
+
+If enabled, include the controller and action names in the subject. Use `:include_controller_and_action_names_in_subject => false` to exclude them.
+
 ##### email_format
 
 *Symbol, default: :text*

--- a/lib/exception_notifier/email_notifier.rb
+++ b/lib/exception_notifier/email_notifier.rb
@@ -9,8 +9,8 @@ module ExceptionNotifier
     attr_accessor(:sender_address, :exception_recipients,
     :pre_callback, :post_callback,
     :email_prefix, :email_format, :sections, :background_sections,
-    :verbose_subject, :normalize_subject, :delivery_method, :mailer_settings,
-    :email_headers, :mailer_parent, :template_path, :deliver_with)
+    :verbose_subject, :normalize_subject, :include_controller_and_action_names_in_subject,
+    :delivery_method, :mailer_settings, :email_headers, :mailer_parent, :template_path, :deliver_with)
 
     module Mailer
       class MissingController
@@ -60,7 +60,7 @@ module ExceptionNotifier
 
           def compose_subject
             subject = "#{@options[:email_prefix]}"
-            subject << "#{@kontroller.controller_name}##{@kontroller.action_name}" if @kontroller
+            subject << "#{@kontroller.controller_name}##{@kontroller.action_name}" if @kontroller && @options[:include_controller_and_action_names_in_subject]
             subject << " (#{@exception.class})"
             subject << " #{@exception.message.inspect}" if @options[:verbose_subject]
             subject = EmailNotifier.normalize_digits(subject) if @options[:normalize_subject]
@@ -142,10 +142,10 @@ module ExceptionNotifier
       options[:mailer_settings] = options.delete(mailer_settings_key)
 
       options.reverse_merge(EmailNotifier.default_options).select{|k,v|[
-        :sender_address, :exception_recipients,
-        :pre_callback, :post_callback,
-        :email_prefix, :email_format, :sections, :background_sections,
-        :verbose_subject, :normalize_subject, :delivery_method, :mailer_settings,
+        :sender_address, :exception_recipients, :pre_callback,
+        :post_callback, :email_prefix, :email_format,
+        :sections, :background_sections, :verbose_subject, :normalize_subject,
+        :include_controller_and_action_names_in_subject, :delivery_method, :mailer_settings,
         :email_headers, :mailer_parent, :template_path, :deliver_with].include?(k)}.each{|k,v| send("#{k}=", v)}
     end
 
@@ -201,6 +201,7 @@ module ExceptionNotifier
         :background_sections => %w(backtrace data),
         :verbose_subject => true,
         :normalize_subject => false,
+        :include_controller_and_action_names_in_subject => true,
         :delivery_method => nil,
         :mailer_settings => nil,
         :email_headers => {},

--- a/test/dummy/test/functional/posts_controller_test.rb
+++ b/test/dummy/test/functional/posts_controller_test.rb
@@ -35,11 +35,7 @@ class PostsControllerTest < ActionController::TestCase
   test "mail subject should have the proper prefix" do
     assert_includes @mail.subject, "[Dummy ERROR]"
   end
-
-  test "mail subject should have controller and action name by default" do
-    assert_includes @mail.subject, "posts#create"
-  end
-
+  
   test "mail subject should include descriptive error message" do
     assert_includes @mail.subject, "(NoMethodError) \"undefined method `nw'"
   end

--- a/test/dummy/test/functional/posts_controller_test.rb
+++ b/test/dummy/test/functional/posts_controller_test.rb
@@ -36,6 +36,10 @@ class PostsControllerTest < ActionController::TestCase
     assert_includes @mail.subject, "[Dummy ERROR]"
   end
 
+  test "mail subject should have controller and action name by default" do
+    assert_includes @mail.subject, "posts#create"
+  end
+
   test "mail subject should include descriptive error message" do
     assert_includes @mail.subject, "(NoMethodError) \"undefined method `nw'"
   end
@@ -143,6 +147,25 @@ class PostsControllerTestWithoutVerboseSubject < ActionController::TestCase
     assert_includes @mail.subject, '[ERROR]'
     assert_includes @mail.subject, '(NoMethodError)'
     refute_includes @mail.subject, 'undefined method'
+  end
+end
+
+class PostsControllerTestWithoutControllerAndActionNames < ActionController::TestCase
+  tests PostsController
+  setup do
+    @email_notifier = ExceptionNotifier::EmailNotifier.new(:include_controller_and_action_names_in_subject => false)
+    begin
+      post :create, method: :post
+    rescue => e
+      @exception = e
+      @mail = @email_notifier.create_email(@exception, {:env => request.env})
+    end
+  end
+
+  test "should include controller and action names in subject" do
+    assert_includes @mail.subject, '[ERROR]'
+    assert_includes @mail.subject, '(NoMethodError)'
+    refute_includes @mail.subject, 'posts#create'
   end
 end
 


### PR DESCRIPTION
Addresses this "issue":
https://github.com/smartinez87/exception_notification/issues/373