### PR TITLE
Add new feature: Errors Grouping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
 install:
   - "gem install bundler"
   - "bundle install --jobs=3 --retry=3"
+  - "mkdir -p test/dummy/tmp/cache"
 gemfile:
   - gemfiles/rails4_0.gemfile
   - gemfiles/rails4_1.gemfile

--- a/lib/exception_notification/rack.rb
+++ b/lib/exception_notification/rack.rb
@@ -6,6 +6,15 @@ module ExceptionNotification
       @app = app
 
       ExceptionNotifier.ignored_exceptions = options.delete(:ignore_exceptions) if options.key?(:ignore_exceptions)
+      ExceptionNotifier.error_grouping = options.delete(:error_grouping) if options.key?(:error_grouping)
+      ExceptionNotifier.error_grouping_period = options.delete(:error_grouping_period) if options.key?(:error_grouping_period)
+      ExceptionNotifier.notification_trigger = options.delete(:notification_trigger) if options.key?(:notification_trigger)
+
+      if options.key?(:error_grouping_cache)
+        ExceptionNotifier.error_grouping_cache = options.delete(:error_grouping_cache)
+      elsif defined?(Rails)
+        ExceptionNotifier.error_grouping_cache = Rails.cache
+      end
 
       if options.key?(:ignore_if)
         rack_ignore = options.delete(:ignore_if)

--- a/lib/exception_notification/rails.rb
+++ b/lib/exception_notification/rails.rb
@@ -2,6 +2,7 @@ module ExceptionNotification
   class Engine < ::Rails::Engine
     config.exception_notification = ExceptionNotifier
     config.exception_notification.logger = Rails.logger
+    config.exception_notification.error_grouping_cache = Rails.cache
 
     config.app_middleware.use ExceptionNotification::Rack
   end

--- a/lib/exception_notifier/campfire_notifier.rb
+++ b/lib/exception_notifier/campfire_notifier.rb
@@ -19,7 +19,11 @@ module ExceptionNotifier
 
     def call(exception, options={})
       if active?
-        message = "A new exception occurred: '#{exception.message}'"
+        message = if options[:accumulated_errors_count].to_i > 1
+          "The exception occurred #{options[:accumulated_errors_count]} times: '#{exception.message}'"
+        else
+          "A new exception occurred: '#{exception.message}'"
+        end
         message += " on '#{exception.backtrace.first}'" if exception.backtrace
         send_notice(exception, options, message) do |msg, _|
           @room.paste msg

--- a/lib/exception_notifier/email_notifier.rb
+++ b/lib/exception_notifier/email_notifier.rb
@@ -60,6 +60,7 @@ module ExceptionNotifier
 
           def compose_subject
             subject = "#{@options[:email_prefix]}"
+            subject << "(#{@options[:accumulated_errors_count]} times) " if @options[:accumulated_errors_count].to_i > 1
             subject << "#{@kontroller.controller_name}##{@kontroller.action_name}" if @kontroller && @options[:include_controller_and_action_names_in_subject]
             subject << " (#{@exception.class})"
             subject << " #{@exception.message.inspect}" if @options[:verbose_subject]

--- a/lib/exception_notifier/irc_notifier.rb
+++ b/lib/exception_notifier/irc_notifier.rb
@@ -7,7 +7,11 @@ module ExceptionNotifier
     end
 
     def call(exception, options={})
+      errors_count = options[:accumulated_errors_count].to_i
+
       message = "'#{exception.message}'"
+      message.prepend("(#{errors_count} times)") if errors_count > 1
+
       message += " on '#{exception.backtrace.first}'" if exception.backtrace
       if active?
         send_notice(exception, options, message) do |msg, _|

--- a/lib/exception_notifier/mattermost_notifier.rb
+++ b/lib/exception_notifier/mattermost_notifier.rb
@@ -91,8 +91,9 @@ module ExceptionNotifier
       def message_header
         text = []
 
+        errors_count = @options[:accumulated_errors_count].to_i
         text << "### :warning: Error 500 in #{Rails.env} :warning:"
-        text << "An *#{@exception.class}* occured" + if @controller then " in *#{controller_and_method}*." else "." end
+        text << "#{errors_count > 1 ? errors_count : 'An'} *#{@exception.class}* occured" + if @controller then " in *#{controller_and_method}*." else "." end
         text << "*#{@exception.message}*"
 
         text

--- a/lib/exception_notifier/modules/error_grouping.rb
+++ b/lib/exception_notifier/modules/error_grouping.rb
@@ -17,7 +17,7 @@ module ExceptionNotifier
       mattr_accessor :error_grouping_cache
     end
 
-    class_methods do
+    module ClassMethods
       # Fallback to the memory store while the specified cache store doesn't work
       #
       def fallback_cache_store

--- a/lib/exception_notifier/modules/error_grouping.rb
+++ b/lib/exception_notifier/modules/error_grouping.rb
@@ -1,3 +1,4 @@
+require 'active_support/core_ext/numeric/time'
 require 'active_support/concern'
 
 module ExceptionNotifier

--- a/lib/exception_notifier/modules/error_grouping.rb
+++ b/lib/exception_notifier/modules/error_grouping.rb
@@ -1,0 +1,76 @@
+require 'active_support/concern'
+
+module ExceptionNotifier
+  module ErrorGrouping
+    extend ActiveSupport::Concern
+
+    included do
+      mattr_accessor :error_grouping
+      self.error_grouping = false
+
+      mattr_accessor :error_grouping_period
+      self.error_grouping_period = 5.minutes
+
+      mattr_accessor :notification_trigger
+
+      mattr_accessor :error_grouping_cache
+    end
+
+    class_methods do
+      # Fallback to the memory store while the specified cache store doesn't work
+      #
+      def fallback_cache_store
+        @fallback_cache_store ||= ActiveSupport::Cache::MemoryStore.new
+      end
+
+      def error_count(error_key)
+        count = begin
+          error_grouping_cache.read(error_key)
+        rescue => e
+          ExceptionNotifier.logger.warn("#{error_grouping_cache.inspect} failed to read, reason: #{e.message}. Falling back to memory cache store.")
+          fallback_cache_store.read(error_key)
+        end
+
+        count.to_i if count
+      end
+
+      def save_error_count(error_key, count)
+        error_grouping_cache.write(error_key, count, expires_in: error_grouping_period)
+      rescue => e
+        ExceptionNotifier.logger.warn("#{error_grouping_cache.inspect} failed to write, reason: #{e.message}. Falling back to memory cache store.")
+        fallback_cache_store.write(error_key, count, expires_in: error_grouping_period)
+      end
+
+      def group_error!(exception, options)
+        message_based_key = "exception:#{Zlib.crc32("#{exception.class.name}\nmessage:#{exception.message}")}"
+        accumulated_errors_count = 1
+
+        if count = error_count(message_based_key)
+          accumulated_errors_count = count + 1
+          save_error_count(message_based_key, accumulated_errors_count)
+        else
+          backtrace_based_key = "exception:#{Zlib.crc32("#{exception.class.name}\npath:#{exception.backtrace.try(:first)}")}"
+
+          if count = Rails.cache.read(backtrace_based_key)
+            accumulated_errors_count = count + 1
+            save_error_count(backtrace_based_key, accumulated_errors_count)
+          else
+            save_error_count(backtrace_based_key, accumulated_errors_count)
+            save_error_count(message_based_key, accumulated_errors_count)
+          end
+        end
+
+        options[:accumulated_errors_count] = accumulated_errors_count
+      end
+
+      def send_notification?(exception, count)
+        if notification_trigger.respond_to?(:call)
+          notification_trigger.call(exception, count)
+        else
+          factor = Math.log2(count)
+          factor.to_i == factor
+        end
+      end
+    end
+  end
+end

--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -20,7 +20,9 @@ module ExceptionNotifier
     end
 
     def call(exception, options={})
-      exception_name = "*#{exception.class.to_s =~ /^[aeiou]/i ? 'An' : 'A'}* `#{exception.class.to_s}`"
+      errors_count = options[:accumulated_errors_count].to_i
+      measure_word = errors_count > 1 ? errors_count : (exception.class.to_s =~ /^[aeiou]/i ? 'An' : 'A')
+      exception_name = "*#{measure_word}* `#{exception.class.to_s}`"
 
       if options[:env].nil?
         data = options[:data] || {}

--- a/test/exception_notification/rack_test.rb
+++ b/test/exception_notification/rack_test.rb
@@ -5,6 +5,14 @@ class RackTest < ActiveSupport::TestCase
   setup do
     @pass_app = Object.new
     @pass_app.stubs(:call).returns([nil, { 'X-Cascade' => 'pass' }, nil])
+
+    @normal_app = Object.new
+    @normal_app.stubs(:call).returns([nil, { }, nil])
+  end
+
+  teardown do
+    ExceptionNotifier.error_grouping = false
+    ExceptionNotifier.notification_trigger = nil
   end
 
   test "should ignore \"X-Cascade\" header by default" do
@@ -17,4 +25,20 @@ class RackTest < ActiveSupport::TestCase
     ExceptionNotification::Rack.new(@pass_app, :ignore_cascade_pass => false).call({})
   end
 
+  test "should assign error_grouping if error_grouping is specified" do
+    refute ExceptionNotifier.error_grouping
+    ExceptionNotification::Rack.new(@normal_app, error_grouping: true).call({})
+    assert ExceptionNotifier.error_grouping
+  end
+
+  test "should assign notification_trigger if notification_trigger is specified" do
+    assert_nil ExceptionNotifier.notification_trigger
+    ExceptionNotification::Rack.new(@normal_app, notification_trigger: lambda {|i| true}).call({})
+    assert_respond_to ExceptionNotifier.notification_trigger, :call
+  end
+
+  test "should set default cache to Rails cache" do
+    ExceptionNotification::Rack.new(@normal_app, error_grouping: true).call({})
+    assert_equal Rails.cache, ExceptionNotifier.error_grouping_cache
+  end
 end

--- a/test/exception_notifier/campfire_notifier_test.rb
+++ b/test/exception_notifier/campfire_notifier_test.rb
@@ -52,6 +52,20 @@ class CampfireNotifierTest < ActiveSupport::TestCase
     assert_nil campfire.call(fake_exception)
   end
 
+  test "should send the new exception message if no :accumulated_errors_count option" do
+    campfire = ExceptionNotifier::CampfireNotifier.new({})
+    campfire.stubs(:active?).returns(true)
+    campfire.expects(:send_notice).with{ |_, _, message| message.start_with?("A new exception occurred") }.once
+    campfire.call(fake_exception)
+  end
+
+  test "shoud send the exception message if :accumulated_errors_count option greater than 1" do
+    campfire = ExceptionNotifier::CampfireNotifier.new({})
+    campfire.stubs(:active?).returns(true)
+    campfire.expects(:send_notice).with{ |_, _, message| message.start_with?("The exception occurred 3 times:") }.once
+    campfire.call(fake_exception, accumulated_errors_count: 3)
+  end
+
   test "should call pre/post_callback if specified" do 
     pre_callback_called, post_callback_called = 0,0
     Tinder::Campfire.stubs(:new).returns(Object.new)

--- a/test/exception_notifier/email_notifier_test.rb
+++ b/test/exception_notifier/email_notifier_test.rb
@@ -218,4 +218,18 @@ class EmailNotifierTest < ActiveSupport::TestCase
     mail = email_notifier.call(@exception)
     assert_equal %w{second@example.com}, mail.to
   end
+
+  test "should prepend accumulated_errors_count in email subject if accumulated_errors_count larger than 1" do
+    ActionMailer::Base.deliveries.clear
+
+    email_notifier = ExceptionNotifier::EmailNotifier.new(
+      :email_prefix => '[Dummy ERROR] ',
+      :sender_address => %{"Dummy Notifier" <dummynotifier@example.com>},
+      :exception_recipients => %w{dummyexceptions@example.com},
+      :delivery_method => :test
+    )
+
+    mail = email_notifier.call(@exception, { accumulated_errors_count: 3 })
+    assert mail.subject.start_with?("[Dummy ERROR] (3 times) (ZeroDivisionError)")
+  end
 end

--- a/test/exception_notifier/irc_notifier_test.rb
+++ b/test/exception_notifier/irc_notifier_test.rb
@@ -16,6 +16,22 @@ class IrcNotifierTest < ActiveSupport::TestCase
     irc.call(fake_exception)
   end
 
+  test "should exclude errors count in message if :accumulated_errors_count nil" do
+    irc = ExceptionNotifier::IrcNotifier.new({})
+    irc.stubs(:active?).returns(true)
+
+    irc.expects(:send_message).with{ |message| message.include?("divided by 0") }.once
+    irc.call(fake_exception)
+  end
+
+  test "should include errors count in message if :accumulated_errors_count is 3" do
+    irc = ExceptionNotifier::IrcNotifier.new({})
+    irc.stubs(:active?).returns(true)
+
+    irc.expects(:send_message).with{ |message| message.include?("(3 times)'divided by 0'") }.once
+    irc.call(fake_exception, accumulated_errors_count: 3)
+  end
+
   test "should call pre/post_callback if specified" do
     pre_callback_called, post_callback_called = 0,0
 

--- a/test/exception_notifier/mattermost_notifier_test.rb
+++ b/test/exception_notifier/mattermost_notifier_test.rb
@@ -77,6 +77,23 @@ class MattermostNotifierTest < ActiveSupport::TestCase
     assert 'password', options[:basic_auth][:password]
   end
 
+  test "should use 'An' for exceptions count if :accumulated_errors_count option is nil" do
+    mattermost_notifier = ExceptionNotifier::MattermostNotifier.new
+    exception = ArgumentError.new("foo")
+    mattermost_notifier.instance_variable_set(:@exception, exception)
+    mattermost_notifier.instance_variable_set(:@options, {})
+
+    assert_includes mattermost_notifier.send(:message_header), "An *ArgumentError* occured."
+  end
+
+  test "shoud use direct errors count if :accumulated_errors_count option is 5" do
+    mattermost_notifier = ExceptionNotifier::MattermostNotifier.new
+    exception = ArgumentError.new("foo")
+    mattermost_notifier.instance_variable_set(:@exception, exception)
+    mattermost_notifier.instance_variable_set(:@options, { accumulated_errors_count: 5 })
+
+    assert_includes mattermost_notifier.send(:message_header), "5 *ArgumentError* occured."
+  end
 end
 
 class FakeHTTParty

--- a/test/exception_notifier/modules/error_grouping_test.rb
+++ b/test/exception_notifier/modules/error_grouping_test.rb
@@ -1,0 +1,166 @@
+require 'test_helper'
+
+class ErrorGroupTest < ActiveSupport::TestCase
+
+  setup do
+    module TestModule
+      include ExceptionNotifier::ErrorGrouping
+      @@error_grouping_cache = ActiveSupport::Cache::FileStore.new("test/dummy/tmp/cache")
+    end
+
+    @exception = RuntimeError.new("ERROR")
+    @exception.stubs(:backtrace).returns(["/path/where/error/raised:1"])
+
+    @exception2 = RuntimeError.new("ERROR2")
+    @exception2.stubs(:backtrace).returns(["/path/where/error/found:2"])
+  end
+
+  teardown do
+    TestModule.error_grouping_cache.clear
+    TestModule.fallback_cache_store.clear
+  end
+
+  test "should add additional option: error_grouping" do
+    assert_respond_to TestModule, :error_grouping
+    assert_respond_to TestModule, :error_grouping=
+  end
+
+  test "should set error_grouping to false default" do
+    assert_equal false, TestModule.error_grouping
+  end
+
+  test "should add additional option: error_grouping_cache" do
+    assert_respond_to TestModule, :error_grouping_cache
+    assert_respond_to TestModule, :error_grouping_cache=
+  end
+
+  test "should add additional option: error_grouping_period" do
+    assert_respond_to TestModule, :error_grouping_period
+    assert_respond_to TestModule, :error_grouping_period=
+  end
+
+  test "shoud set error_grouping_period to 5.minutes default" do
+    assert_equal 300, TestModule.error_grouping_period
+  end
+
+  test "should add additional option: notification_trigger" do
+    assert_respond_to TestModule, :notification_trigger
+    assert_respond_to TestModule, :notification_trigger=
+  end
+
+  test "should return errors count nil when not same error for .error_count" do
+    assert_nil TestModule.error_count("something")
+  end
+
+  test "should return errors count when same error for .error_count" do
+    TestModule.error_grouping_cache.write("error_key", 13)
+    assert_equal 13, TestModule.error_count("error_key")
+  end
+
+  test "should fallback to memory store cache if specified cache store failed to read" do
+    TestModule.error_grouping_cache.stubs(:read).raises(RuntimeError.new "Failed to read")
+    original_fallback = TestModule.fallback_cache_store
+    TestModule.expects(:fallback_cache_store).returns(original_fallback).at_least_once
+
+    assert_nil TestModule.error_count("something_to_read")
+  end
+
+  test "should save error with count for .save_error_count" do
+    count = rand(1..10)
+
+    TestModule.save_error_count("error_key", count)
+    assert_equal count, TestModule.error_grouping_cache.read("error_key")
+  end
+
+  test "should fallback to memory store cache if specified cache store failed to write" do
+    TestModule.error_grouping_cache.stubs(:write).raises(RuntimeError.new "Failed to write")
+    original_fallback = TestModule.fallback_cache_store
+    TestModule.expects(:fallback_cache_store).returns(original_fallback).at_least_once
+
+    assert TestModule.save_error_count("something_to_cache", rand(1..10))
+  end
+
+  test "should save accumulated_errors_count into options" do
+    options = {}
+    TestModule.group_error!(@exception, options)
+
+    assert_equal 1, options[:accumulated_errors_count]
+  end
+
+  test "should not group error if different exception in .group_error!" do
+    options1 = {}
+    TestModule.expects(:save_error_count).with{|key, count| key.is_a?(String) && count == 1}.times(4).returns(true)
+    TestModule.group_error!(@exception, options1)
+
+    options2 = {}
+    TestModule.group_error!(NoMethodError.new("method not found"), options2)
+
+    assert_equal 1, options1[:accumulated_errors_count]
+    assert_equal 1, options2[:accumulated_errors_count]
+  end
+
+  test "should not group error is same exception but different message or backtrace" do
+    options1 = {}
+    TestModule.expects(:save_error_count).with{|key, count| key.is_a?(String) && count == 1}.times(4).returns(true)
+    TestModule.group_error!(@exception, options1)
+
+    options2 = {}
+    TestModule.group_error!(@exception2, options2)
+
+    assert_equal 1, options1[:accumulated_errors_count]
+    assert_equal 1, options2[:accumulated_errors_count]
+  end
+
+  test "should group error if same exception and message" do
+    options = {}
+
+    10.times do |i|
+      @exception2.stubs(:backtrace).returns(["/path:#{i}"])
+      TestModule.group_error!(@exception2, options)
+    end
+
+    assert_equal 10, options[:accumulated_errors_count]
+  end
+
+  test "should group error if same exception and backtrace" do
+    options = {}
+
+    10.times do |i|
+      @exception2.stubs(:message).returns("ERRORS#{i}")
+      TestModule.group_error!(@exception2, options)
+    end
+
+    assert_equal 10, options[:accumulated_errors_count]
+  end
+
+  test "should group error by that message have high priority" do
+    message_based_key = "exception:#{Zlib.crc32("RuntimeError\nmessage:ERROR")}"
+    backtrace_based_key = "exception:#{Zlib.crc32("RuntimeError\n/path/where/error/raised:1")}"
+
+    TestModule.save_error_count(message_based_key, 1)
+    TestModule.save_error_count(backtrace_based_key, 1)
+
+    TestModule.expects(:save_error_count).with(message_based_key, 2).once
+    TestModule.expects(:save_error_count).with(backtrace_based_key, 2).never
+
+    TestModule.group_error!(@exception, {})
+  end
+
+  test "use default formula if not specify notification_trigger in .send_notification?" do
+    TestModule.stubs(:notification_trigger).returns(nil)
+
+    count = 16
+    Math.expects(:log2).with(count).returns(4)
+
+    assert TestModule.send_notification?(@exception, count)
+  end
+
+  test "use specified trigger in .send_notification?" do
+    trigger = Proc.new { |exception, count| count % 4 == 0 }
+    TestModule.stubs(:notification_trigger).returns(trigger)
+
+    count = 16
+    trigger.expects(:call).with(@exception, count).returns(true)
+    assert TestModule.send_notification?(@exception, count)
+  end
+end

--- a/test/exception_notifier_test.rb
+++ b/test/exception_notifier_test.rb
@@ -1,6 +1,21 @@
 require 'test_helper'
 
+class ExceptionOne < StandardError;end
+class ExceptionTwo < StandardError;end
+
 class ExceptionNotifierTest < ActiveSupport::TestCase
+  setup do
+    @notifier_calls = 0
+    @test_notifier = lambda { |exception, options| @notifier_calls += 1 }
+  end
+
+  teardown do
+    ExceptionNotifier.error_grouping = false
+    ExceptionNotifier.notification_trigger = nil
+    ExceptionNotifier.class_eval("@@notifiers.delete_if { |k, _| k.to_s != \"email\"}")  # reset notifiers
+    Rails.cache.clear
+  end
+
   test "should have default ignored exceptions" do
     assert_equal ExceptionNotifier.ignored_exceptions,
       ['ActiveRecord::RecordNotFound', 'Mongoid::Errors::DocumentNotFound', 'AbstractController::ActionNotFound',
@@ -69,37 +84,67 @@ class ExceptionNotifierTest < ActiveSupport::TestCase
       env != "production"
     end
 
-    notifier_calls = 0
-    test_notifier = lambda { |exception, options| notifier_calls += 1 }
-    ExceptionNotifier.register_exception_notifier(:test, test_notifier)
+    ExceptionNotifier.register_exception_notifier(:test, @test_notifier)
 
     exception = StandardError.new
 
     ExceptionNotifier.notify_exception(exception, {:notifiers => :test})
-    assert_equal notifier_calls, 1
+    assert_equal @notifier_calls, 1
 
     env = "development"
     ExceptionNotifier.notify_exception(exception, {:notifiers => :test})
-    assert_equal notifier_calls, 1
+    assert_equal @notifier_calls, 1
 
     ExceptionNotifier.clear_ignore_conditions!
-    ExceptionNotifier.unregister_exception_notifier(:test)
   end
 
   test "should not send notification if one of ignored exceptions" do
-    notifier_calls = 0
-    test_notifier = lambda { |exception, options| notifier_calls += 1 }
-    ExceptionNotifier.register_exception_notifier(:test, test_notifier)
+    ExceptionNotifier.register_exception_notifier(:test, @test_notifier)
 
     exception = StandardError.new
 
     ExceptionNotifier.notify_exception(exception, {:notifiers => :test})
-    assert_equal notifier_calls, 1
+    assert_equal @notifier_calls, 1
 
     ExceptionNotifier.notify_exception(exception, {:notifiers => :test, :ignore_exceptions => 'StandardError' })
-    assert_equal notifier_calls, 1
-
-    ExceptionNotifier.unregister_exception_notifier(:test)
+    assert_equal @notifier_calls, 1
   end
 
+  test "should not call group_error! or send_notification? if error_grouping false" do
+    exception = StandardError.new
+    ExceptionNotifier.expects(:group_error!).never
+    ExceptionNotifier.expects(:send_notification?).never
+
+    ExceptionNotifier.notify_exception(exception)
+  end
+
+  test "should call group_error! and send_notification? if error_grouping true" do
+    ExceptionNotifier.error_grouping = true
+
+    exception = StandardError.new
+    ExceptionNotifier.expects(:group_error!).once
+    ExceptionNotifier.expects(:send_notification?).once
+
+    ExceptionNotifier.notify_exception(exception)
+  end
+
+  test "should skip notification if send_notification? is false" do
+    ExceptionNotifier.error_grouping = true
+
+    exception = StandardError.new
+    ExceptionNotifier.expects(:group_error!).once.returns(1)
+    ExceptionNotifier.expects(:send_notification?).with(exception, 1).once.returns(false)
+
+    refute ExceptionNotifier.notify_exception(exception)
+  end
+
+  test "should send notification if send_notification? is true" do
+    ExceptionNotifier.error_grouping = true
+
+    exception = StandardError.new
+    ExceptionNotifier.expects(:group_error!).once.returns(1)
+    ExceptionNotifier.expects(:send_notification?).with(exception, 1).once.returns(true)
+
+    assert ExceptionNotifier.notify_exception(exception)
+  end
 end


### PR DESCRIPTION
Exception notification sends every notification for each raised error, this is good if the error is not raised frequently. But unfortunately, sometimes we have to meet a problem: if a common  error produced everywhere, for example, a db connection problem, we may receive a large amount of exception mails for a same error.

I think it is better to group errors and only send them with recorded errors number at some threshold so I use a formula to determine when an error should be notified. Currently it do this when an accumulated error count is 1, 3, 6, 9, 10, 100, 1000, ..., 10**n (n is an integer).

I keep the original behaviour and expose an option to allow users to enable the new feature explicitly, and also other two options to control the formula and the cache time for error's accumulated count. You can also visit https://github.com/Martin91/exception_notification/tree/implement-errors-grouping#grouping-error to review this.

The below shows an example I test in my real application.
![image](https://cloud.githubusercontent.com/assets/2900644/23333283/04c37a92-fbc4-11e6-95d7-4804a997b2b9.png)

Thanks for your patient time and I am looking forward to get more suggestion.