### PR TITLE
Allow to set slack attachment color via additional_parameters

### DIFF
--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -30,7 +30,7 @@ module ExceptionNotifier
 
         kontroller = env['action_controller.instance']
         request = "#{env['REQUEST_METHOD']} <#{env['REQUEST_URI']}>"
-        text = "#{exception_name} *occurred while* `#{env['REQUEST_METHOD']} <#{env['REQUEST_URI']}>`"
+        text = "#{exception_name} *occurred while* `#{request}`"
         text += " *was processed by* `#{kontroller.controller_name}##{kontroller.action_name}`" if kontroller
         text += "\n"
       end

--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -12,6 +12,7 @@ module ExceptionNotifier
 
         webhook_url = options.fetch(:webhook_url)
         @message_opts = options.fetch(:additional_parameters, {})
+        @color = @message_opts.delete(:color) { 'danger' }
         @notifier = Slack::Notifier.new webhook_url, options
       rescue
         @notifier = nil
@@ -36,7 +37,7 @@ module ExceptionNotifier
       end
 
       clean_message = exception.message.gsub("`", "'")
-      fields = [ { title: 'Exception', value: clean_message} ]
+      fields = [ { title: 'Exception', value: clean_message } ]
 
       fields.push({ title: 'Hostname', value: Socket.gethostname })
 
@@ -51,7 +52,7 @@ module ExceptionNotifier
         fields.push({ title: 'Data', value: "```#{data_string}```" })
       end
 
-      attchs = [color: 'danger', text: text, fields: fields, mrkdwn_in: %w(text fields)]
+      attchs = [color: @color, text: text, fields: fields, mrkdwn_in: %w(text fields)]
 
       if valid?
         send_notice(exception, options, clean_message, @message_opts.merge(attachments: attchs)) do |msg, message_opts|

--- a/test/exception_notifier/slack_notifier_test.rb
+++ b/test/exception_notifier/slack_notifier_test.rb
@@ -43,7 +43,8 @@ class SlackNotifierTest < ActiveSupport::TestCase
     slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
     slack_notifier.call(@exception)
 
-    assert_equal slack_notifier.notifier.channel, options[:channel]
+    channel = slack_notifier.notifier.config.defaults[:channel]
+    assert_equal channel, options[:channel]
   end
 
   test "should send the notification to the specified username" do
@@ -57,7 +58,8 @@ class SlackNotifierTest < ActiveSupport::TestCase
     slack_notifier = ExceptionNotifier::SlackNotifier.new(options)
     slack_notifier.call(@exception)
 
-    assert_equal slack_notifier.notifier.username, options[:username]
+    username = slack_notifier.notifier.config.defaults[:username]
+    assert_equal username, options[:username]
   end
 
   test "should send the notification with specific backtrace lines" do


### PR DESCRIPTION
Hi,
Thank you for the gem.

I thought it might be useful to have an ability to set custom color for slack attachment, for instance, based on `Rails.env`.

I think `additional_parameters` can be suitable place for it, but maybe there is more elegant solution.
What do you think?