### PR TITLE
Add option to connect to connect to Enterprise HipChat Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,12 @@ Color of the message. Default : 'red'.
 
 Message will appear from this nickname. Default : 'Exception'.
 
+##### server_url
+
+*String, optional*
+
+Custom Server URL for self-hosted, Enterprise HipChat Server
+
 For all options & possible values see [Hipchat API](https://www.hipchat.com/docs/api/method/rooms/message).
 
 ### IRC notifier

--- a/lib/exception_notifier/hipchat_notifier.rb
+++ b/lib/exception_notifier/hipchat_notifier.rb
@@ -13,6 +13,7 @@ module ExceptionNotifier
         opts              = {
                               :api_version => options.delete(:api_version) || 'v1'
                             }
+        opts[:server_url] = options.delete(:server_url) if options[:server_url]
         @from             = options.delete(:from) || 'Exception'
         @room             = HipChat::Client.new(api_token, opts)[room_name]
         @message_template = options.delete(:message_template) || ->(exception, errors_count) {

--- a/test/exception_notifier/hipchat_notifier_test.rb
+++ b/test/exception_notifier/hipchat_notifier_test.rb
@@ -175,6 +175,20 @@ class HipchatNotifierTest < ActiveSupport::TestCase
     hipchat.call(fake_exception)
   end
 
+  test "should allow server_url value (for a self-hosted HipChat Server) if set" do
+    options = {
+      :api_token   => 'good_token',
+      :room_name   => 'room_name',
+      :api_version => 'v2',
+      :server_url  => 'https://domain.com',
+    }
+
+    HipChat::Client.stubs(:new).with('good_token', {:api_version => 'v2', :server_url => 'https://domain.com'}).returns({})
+
+    hipchat = ExceptionNotifier::HipchatNotifier.new(options)
+    hipchat.call(fake_exception)
+  end
+
   private
 
   def fake_body


### PR DESCRIPTION
Currently there is not a way to send notifications to HipChat that is hosted on an enterprise server.

Fortunately the fix is simple - HipChat::Client has an option for `:server_url` that allows you to specify the address of the enterprise server: [HipChat Wrapper README - Custom Server URL](https://github.com/hipchat/hipchat-rb#custom-server-url)

In addition to this PR, I've also submitted an issue: [382](https://github.com/smartinez87/exception_notification/issues/382)