### PR TITLE
Ignore subclasses of ignored exceptions

### DIFF
--- a/lib/exception_notifier.rb
+++ b/lib/exception_notifier.rb
@@ -104,7 +104,9 @@ module ExceptionNotifier
     end
 
     def ignored_exception?(ignore_array, exception)
-      (Array(ignored_exceptions) + Array(ignore_array)).map(&:to_s).include?(exception.class.name)
+      all_ignored_exceptions = (Array(ignored_exceptions) + Array(ignore_array)).map(&:to_s)
+      exception_ancestors = exception.class.ancestors.map(&:to_s)
+      !(all_ignored_exceptions & exception_ancestors).empty?
     end
 
     def fire_notification(notifier_name, exception, options)

--- a/test/exception_notifier_test.rb
+++ b/test/exception_notifier_test.rb
@@ -110,6 +110,21 @@ class ExceptionNotifierTest < ActiveSupport::TestCase
     assert_equal @notifier_calls, 1
   end
 
+  test "should not send notification if subclass of one of ignored exceptions" do
+    ExceptionNotifier.register_exception_notifier(:test, @test_notifier)
+
+    class StandardErrorSubclass < StandardError
+    end
+
+    exception = StandardErrorSubclass.new
+
+    ExceptionNotifier.notify_exception(exception, {:notifiers => :test})
+    assert_equal @notifier_calls, 1
+
+    ExceptionNotifier.notify_exception(exception, {:notifiers => :test, :ignore_exceptions => 'StandardError' })
+    assert_equal @notifier_calls, 1
+  end
+
   test "should not call group_error! or send_notification? if error_grouping false" do
     exception = StandardError.new
     ExceptionNotifier.expects(:group_error!).never


### PR DESCRIPTION
We have a ton of exceptions inheriting from a common parent exception, and we'd like to be able to ignore them all in one go by adding that parent exception to the list of ignored exceptions so that we can forget about it no matter how many new sub-exceptions are added.