### PR TITLE
support additional fields for slack attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,12 @@ more information. Default: 'incoming-webhook'
 
 Contains additional payload for a message (e.g avatar, attachments, etc). See [slack-notifier](https://github.com/stevenosloan/slack-notifier#additional-parameters) for more information.. Default: '{}'
 
+##### additional_fields
+
+*Array of Hashes, optional*
+
+Contains additional fields that will be added to the attachement. See [Slack documentation](https://api.slack.com/docs/message-attachments).
+
 ## Mattermost notifier
 
 Post notification in a mattermost channel via [incoming webhook](http://docs.mattermost.com/developer/webhooks-incoming.html)
@@ -606,7 +612,7 @@ Just add the [HTTParty](https://github.com/jnunemaker/httparty) gem to your `Gem
 gem 'httparty'
 ```
 
-To configure it, you **need** to set the `webhook_url` option.  
+To configure it, you **need** to set the `webhook_url` option.
 You can also specify an other channel with `channel` option.
 
 ```ruby
@@ -622,7 +628,7 @@ Rails.application.config.middleware.use ExceptionNotification::Rack,
   }
 ```
 
-If you are using Github or Gitlab for issues tracking, you can specify `git_url` as follow to add a *Create issue* link in you notification.  
+If you are using Github or Gitlab for issues tracking, you can specify `git_url` as follow to add a *Create issue* link in you notification.
 By default this will use your Rails application name to match the git repository. If yours differ you can specify `app_name`.
 
 

--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -9,6 +9,7 @@ module ExceptionNotifier
       begin
         @ignore_data_if = options[:ignore_data_if]
         @backtrace_lines = options.fetch(:backtrace_lines, 10)
+        @additional_fields = options[:additional_fields]
 
         webhook_url = options.fetch(:webhook_url)
         @message_opts = options.fetch(:additional_parameters, {})
@@ -53,6 +54,8 @@ module ExceptionNotifier
         data_string = data.map{|k,v| "#{k}: #{v}"}.join("\n")
         fields.push({ title: 'Data', value: "```#{data_string}```" })
       end
+
+      fields.concat(@additional_fields) if @additional_fields
 
       attchs = [color: @color, text: text, fields: fields, mrkdwn_in: %w(text fields)]
 


### PR DESCRIPTION
As mentioned in #292 the support of **additional fields for the slack notifier** is useful. With this PR I've added the support of it.

## Example configuration

```ruby
slack_options = {
  channel: "#errors",
  backtrace_lines: 1000,
  webhook_url: "https://hooks.slack.com/...................",

  # adding an additional field to the slack message
  additional_fields: [
    {
      title: "Branch",
      value: ENV["BRANCH"],
      short: true
    }
  ]
}
```

Any improvements suggested?

