### PR TITLE
update rubies for travis, add rails 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.1.10
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
 env:
 - COVERALLS_SILENT=true
 install:
@@ -14,7 +15,10 @@ gemfile:
   - gemfiles/rails4_1.gemfile
   - gemfiles/rails4_2.gemfile
   - gemfiles/rails5_0.gemfile
+  - gemfiles/rails5_1.gemfile
 matrix:
   exclude:
-    - rvm: 2.1.9
+    - rvm: 2.1.10
       gemfile: gemfiles/rails5_0.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/rails5_1.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: ruby
 rvm:
   - 2.1.10
-  - 2.2.8
-  - 2.3.5
-  - 2.4.2
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
 env:
 - COVERALLS_SILENT=true
 install:
@@ -22,3 +23,12 @@ matrix:
       gemfile: gemfiles/rails5_0.gemfile
     - rvm: 2.1.10
       gemfile: gemfiles/rails5_1.gemfile
+    # rails <=4.1 segfaults with ruby 2.4+
+    - rvm: 2.4.3
+      gemfile: gemfiles/rails4_0.gemfile
+    - rvm: 2.4.3
+      gemfile: gemfiles/rails4_1.gemfile
+    - rvm: 2.5.0
+      gemfile: gemfiles/rails4_0.gemfile
+    - rvm: 2.5.0
+      gemfile: gemfiles/rails4_1.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -1,8 +1,7 @@
-rails_versions = ['~> 4.0.5', '~> 4.1.1', '~> 4.2.0', '~> 5.0.0']
+rails_versions = ['~> 4.0.5', '~> 4.1.1', '~> 4.2.0', '~> 5.0.0', '~> 5.1.0']
 
 rails_versions.each do |rails_version|
   appraise "rails#{rails_version.slice(/\d+\.\d+/).gsub('.', '_')}" do
     gem 'rails', rails_version
-    gem "sqlite3"
   end
 end

--- a/gemfiles/rails4_0.gemfile
+++ b/gemfiles/rails4_0.gemfile
@@ -3,6 +3,5 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.0.5"
-gem "sqlite3"
 
 gemspec :path => "../"

--- a/gemfiles/rails4_1.gemfile
+++ b/gemfiles/rails4_1.gemfile
@@ -3,6 +3,5 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.1.1"
-gem "sqlite3"
 
 gemspec :path => "../"

--- a/gemfiles/rails4_2.gemfile
+++ b/gemfiles/rails4_2.gemfile
@@ -3,6 +3,5 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
-gem "sqlite3"
 
 gemspec :path => "../"

--- a/gemfiles/rails5_1.gemfile
+++ b/gemfiles/rails5_1.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 5.0.0"
+gem "rails", "~> 5.1.0"
 
 gemspec :path => "../"


### PR DESCRIPTION
This updates the ruby versions used by travis and adds an appraisal for rails 5.1.

Also removed sqlite3 from Appraisals, that should not be needed since it's already listed in the gemspec.