### PR TITLE
Make `ExceptionNotifier.notify_exception` to receive a block

### DIFF
--- a/lib/exception_notifier.rb
+++ b/lib/exception_notifier.rb
@@ -42,7 +42,7 @@ module ExceptionNotifier
       self.testing_mode = true
     end
 
-    def notify_exception(exception, options={})
+    def notify_exception(exception, options={}, &block)
       return false if ignored_exception?(options[:ignore_exceptions], exception)
       return false if ignored?(exception, options)
       if error_grouping
@@ -52,7 +52,7 @@ module ExceptionNotifier
 
       selected_notifiers = options.delete(:notifiers) || notifiers
       [*selected_notifiers].each do |notifier|
-        fire_notification(notifier, exception, options.dup)
+        fire_notification(notifier, exception, options.dup, &block)
       end
       true
     end
@@ -109,9 +109,9 @@ module ExceptionNotifier
       !(all_ignored_exceptions & exception_ancestors).empty?
     end
 
-    def fire_notification(notifier_name, exception, options)
+    def fire_notification(notifier_name, exception, options, &block)
       notifier = registered_exception_notifier(notifier_name)
-      notifier.call(exception, options)
+      notifier.call(exception, options, &block)
     rescue Exception => e
       raise e if @@testing_mode
 

--- a/test/exception_notifier_test.rb
+++ b/test/exception_notifier_test.rb
@@ -125,6 +125,20 @@ class ExceptionNotifierTest < ActiveSupport::TestCase
     assert_equal @notifier_calls, 1
   end
 
+  test "should call received block" do
+    @block_called = false
+    notifier = lambda { |exception, options, &block| block.call }
+    ExceptionNotifier.register_exception_notifier(:test, notifier)
+
+    exception = ExceptionOne.new
+
+    ExceptionNotifier.notify_exception(exception) do
+      @block_called = true
+    end
+
+    assert @block_called
+  end
+
   test "should not call group_error! or send_notification? if error_grouping false" do
     exception = StandardError.new
     ExceptionNotifier.expects(:group_error!).never


### PR DESCRIPTION


Problem
===


I'm a maintainer of [exception_notification-bugsnag](https://github.com/pocke/exception_notification-bugsnag).

We cannot use a hash as option since bugsnag gem version 6, should use a block instead.

> https://github.com/bugsnag/bugsnag-ruby/blob/master/UPGRADING.md#notifying
> 
> * `notify` now only supports block syntax. Replace usage of the overrides hash with a block
> 
>   ```diff
>   - Bugsnag.notify(e, {severity: 'info'})
>   + Bugsnag.notify(e) do |report|
>   +   report.severity = 'info'
>   + end
>   ```

So, I created a patch for exception_notification-bugsnag. The patch makes it aware of a block.
https://github.com/pocke/exception_notification-bugsnag/pull/6

For example:

```ruby
ExceptionNotifier::BugsnagNotifier.call(exception) do
  do_something
end
```


This patch works well when `ExceptionNotifier::BugsnagNotifier.call` is called directly.  However it does not work when it is called through `ExceptionNotifier.notify_exception`. Because `ExceptionNotifier.notify_exception` ignores received block.


Solution
===


This change makes `ExceptionNotifier.notify_exception` to receive a block, and pass the block to each notifiers.