### PR TITLE
Removed \n into irc notifier message

### DIFF
--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'exception_notification'
-  s.version = '4.2.2'
+  s.version = '4.2.3'
   s.authors = ["Jamis Buck", "Josh Peek"]
   s.date = %q{2017-08-12}
   s.summary = "Exception notification for Rails apps"

--- a/lib/exception_notifier/irc_notifier.rb
+++ b/lib/exception_notifier/irc_notifier.rb
@@ -13,6 +13,7 @@ module ExceptionNotifier
       message.prepend("(#{errors_count} times)") if errors_count > 1
 
       message += " on '#{exception.backtrace.first}'" if exception.backtrace
+      message.tr!("\n", ' ')
       if active?
         send_notice(exception, options, message) do |msg, _|
           send_message([*@config.prefix, *msg].join(' '))


### PR DESCRIPTION
Hello,

I've to remove \n into the message when it's supposed to be sent into IRC.
Maybe would have been better to split by this character and send a message for each line, but it suits well for my usage.

Feel free to accept this Pull Request if you like it 👍 

Thank you!