### PR TITLE
enhance ignore_if option to allow by-notifier customization

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,10 @@ Metrics/ModuleLength:
   Exclude:
     - "lib/exception_notifier.rb"
 
+Metrics/ClassLength:
+  Exclude:
+    - "test/**/*.rb"
+
 Metrics/MethodLength:
   Exclude:
     - "lib/exception_notifier/email_notifier.rb"

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -51,6 +51,7 @@ Style/ClassVars:
   Exclude:
     - 'lib/exception_notifier.rb'
     - 'test/exception_notifier/modules/error_grouping_test.rb'
+    - 'test/support/exception_notifier_helper.rb'
 
 # Offense count: 2
 Style/MethodMissingSuper:

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ You can choose to ignore certain exceptions, which will make ExceptionNotificati
 
 * `:ignore_if`         - Custom (i.e. ignore exceptions that satisfy some condition)
 
+* `:ignore_notifer_if` - Custom (i.e. let each notifier ignore exceptions if by-notifier condition is satisfied)
+
 
 ### :ignore_exceptions
 
@@ -175,7 +177,7 @@ Rails.application.config.middleware.use ExceptionNotification::Rack,
 
 *Lambda, default: nil*
 
-Last but not least, you can ignore exceptions based on a condition. Take a look:
+You can ignore exceptions based on a condition. Take a look:
 
 ```ruby
 Rails.application.config.middleware.use ExceptionNotification::Rack,
@@ -188,6 +190,32 @@ Rails.application.config.middleware.use ExceptionNotification::Rack,
 ```
 
 You can make use of both the environment and the exception inside the lambda to decide wether to avoid or not sending the notification.
+
+### :ignore_notifier_if
+
+* Hash of Lambda, default: nil*
+
+In case you want a notifier to ignore certain exceptions, but don't want other notifiers to skip them, you can set by-notifier ignore options.
+By setting below, each notifier will ignore exceptions when its corresponding condition is met.
+
+```ruby
+Rails.application.config.middleware.use ExceptionNotification::Rack,
+                                        ignore_notifier_if: {
+                                          email: ->(env, exception) { !Rails.env.production? },
+                                          slack: ->(env, exception) { exception.message =~ /^Couldn't find Page with ID=/ }
+                                        }
+
+                                        email: {
+                                          sender_address: %{"notifier" <notifier@example.com>},
+                                          exception_recipients: %w{exceptions@example.com}
+                                        },
+                                        slack: {
+                                          webhook_url: '[Your webhook url]',
+                                          channel: '#exceptions',
+                                        }
+```
+
+To customize each condition, you can make use of environment and the exception object inside the lambda.
 
 ## Rack X-Cascade Header
 

--- a/lib/exception_notification/rack.rb
+++ b/lib/exception_notification/rack.rb
@@ -27,6 +27,15 @@ module ExceptionNotification
         end
       end
 
+      if options.key?(:ignore_notifier_if)
+        rack_ignore_by_notifier = options.delete(:ignore_notifier_if)
+        rack_ignore_by_notifier.each do |notifier, proc|
+          ExceptionNotifier.ignore_notifier_if(notifier) do |exception, opts|
+            opts.key?(:env) && proc.call(opts[:env], exception)
+          end
+        end
+      end
+
       ExceptionNotifier.ignore_crawlers(options.delete(:ignore_crawlers)) if options.key?(:ignore_crawlers)
 
       @ignore_cascade_pass = options.delete(:ignore_cascade_pass) { true }

--- a/test/exception_notification/rack_test.rb
+++ b/test/exception_notification/rack_test.rb
@@ -59,4 +59,49 @@ class RackTest < ActiveSupport::TestCase
       refute env['exception_notifier.delivered']
     end
   end
+
+  test 'should ignore exceptions if ignore_if condition is met' do
+    exception_app = Object.new
+    exception_app.stubs(:call).raises(RuntimeError)
+
+    env = {}
+
+    begin
+      ExceptionNotification::Rack.new(
+        exception_app,
+        ignore_if: ->(_env, exception) { exception.is_a? RuntimeError }
+      ).call(env)
+
+      flunk
+    rescue StandardError
+      refute env['exception_notifier.delivered']
+    end
+  end
+
+  test 'should ignore exceptions with notifiers that satisfies ignore_notifier_if condition' do
+    exception_app = Object.new
+    exception_app.stubs(:call).raises(RuntimeError)
+
+    notifier1_called = notifier2_called = false
+    notifier1 = ->(_exception, _options) { notifier1_called = true }
+    notifier2 = ->(_exception, _options) { notifier2_called = true }
+
+    env = {}
+
+    begin
+      ExceptionNotification::Rack.new(
+        exception_app,
+        ignore_notifier_if: {
+          notifier1: ->(_env, exception) { exception.is_a? RuntimeError }
+        },
+        notifier1: notifier1,
+        notifier2: notifier2
+      ).call(env)
+
+      flunk
+    rescue StandardError
+      refute notifier1_called
+      assert notifier2_called
+    end
+  end
 end

--- a/test/exception_notification/rack_test.rb
+++ b/test/exception_notification/rack_test.rb
@@ -12,8 +12,7 @@ class RackTest < ActiveSupport::TestCase
   end
 
   teardown do
-    ExceptionNotifier.error_grouping = false
-    ExceptionNotifier.notification_trigger = nil
+    ExceptionNotifier.reset_notifiers!
   end
 
   test 'should ignore "X-Cascade" header by default' do

--- a/test/exception_notifier_test.rb
+++ b/test/exception_notifier_test.rb
@@ -110,6 +110,87 @@ class ExceptionNotifierTest < ActiveSupport::TestCase
     ExceptionNotifier.clear_ignore_conditions!
   end
 
+  test 'should ignore exception if satisfies by-notifier conditional ignore' do
+    notifier1_calls = 0
+    notifier1 = ->(_exception, _options) { notifier1_calls += 1 }
+    ExceptionNotifier.register_exception_notifier(:notifier1, notifier1)
+
+    notifier2_calls = 0
+    notifier2 = ->(_exception, _options) { notifier2_calls += 1 }
+    ExceptionNotifier.register_exception_notifier(:notifier2, notifier2)
+
+    env = 'production'
+    ExceptionNotifier.ignore_notifier_if(:notifier1) do |_exception, _options|
+      env == 'development'
+    end
+    ExceptionNotifier.ignore_notifier_if(:notifier2) do |_exception, _options|
+      env == 'production'
+    end
+
+    exception = StandardError.new
+
+    ExceptionNotifier.notify_exception(exception)
+    assert_equal notifier1_calls, 1
+    assert_equal notifier2_calls, 0
+
+    env = 'development'
+
+    ExceptionNotifier.notify_exception(exception)
+    assert_equal notifier1_calls, 1
+    assert_equal notifier2_calls, 1
+
+    env = 'test'
+
+    ExceptionNotifier.notify_exception(exception)
+    assert_equal notifier1_calls, 2
+    assert_equal notifier2_calls, 2
+
+    ExceptionNotifier.clear_ignore_conditions!
+  end
+
+  test 'should return false if all the registered notifiers are ignored' do
+    ExceptionNotifier.notifiers.each do |notifier|
+      # make sure to register no other notifiers but the tested ones
+      ExceptionNotifier.unregister_exception_notifier(notifier)
+    end
+
+    ExceptionNotifier.register_exception_notifier(:notifier1, ->(_, _) {})
+    ExceptionNotifier.register_exception_notifier(:notifier2, ->(_, _) {})
+
+    ExceptionNotifier.ignore_notifier_if(:notifier1) do |exception, _options|
+      exception.message =~ /non_critical_error/
+    end
+    ExceptionNotifier.ignore_notifier_if(:notifier2) do |exception, _options|
+      exception.message =~ /non_critical_error/
+    end
+
+    exception = StandardError.new('a non_critical_error occured.')
+
+    refute ExceptionNotifier.notify_exception(exception)
+
+    ExceptionNotifier.clear_ignore_conditions!
+  end
+
+  test 'should return true if one of the notifiers fires' do
+    ExceptionNotifier.notifiers.each do |notifier|
+      # make sure to register no other notifiers but the tested ones
+      ExceptionNotifier.unregister_exception_notifier(notifier)
+    end
+
+    ExceptionNotifier.register_exception_notifier(:notifier1, ->(_, _) {})
+    ExceptionNotifier.register_exception_notifier(:notifier2, ->(_, _) {})
+
+    ExceptionNotifier.ignore_notifier_if(:notifier1) do |exception, _options|
+      exception.message =~ /non-critical\serror/
+    end
+
+    exception = StandardError.new('a non-critical error occured')
+
+    assert ExceptionNotifier.notify_exception(exception)
+
+    ExceptionNotifier.clear_ignore_conditions!
+  end
+
   test 'should not send notification if one of ignored exceptions' do
     ExceptionNotifier.register_exception_notifier(:test, @test_notifier)
 

--- a/test/support/exception_notifier_helper.rb
+++ b/test/support/exception_notifier_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# this extension allows ExceptionNotifier to reset all the glocal settings
+# (i.e. class vars that otherwise remains during the test)
+# please remembeer to call this method each time after you set such settings
+# to prevent order dependent test fails.
+module ExceptionNotifier
+  def self.reset_notifiers!
+    @@notifiers = {}
+    clear_ignore_conditions!
+    ExceptionNotifier.error_grouping = false
+    ExceptionNotifier.notification_trigger = nil
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,8 @@ require 'active_support/test_case'
 require 'action_mailer'
 
 ExceptionNotifier.testing_mode!
+require 'support/exception_notifier_helper'
+
 Time.zone = 'UTC'
 ActionMailer::Base.delivery_method = :test
 ActionMailer::Base.append_view_path "#{File.dirname(__FILE__)}/support/views"


### PR DESCRIPTION

Hi, here is a small PR to enhance `ignore_if` option to allow notifier specific conditions.

### Original Issue

(The original proposal is [here](https://github.com/smartinez87/exception_notification/issues/418) )

### Tests & Documents added

Tests are added to make sure:

* it's __NOT__ breaking the current `ignore_if` behaviors
* it allows us to ignore the specified notifier for certain errors (new API)

### Advises needed..

Would be great if you have any inputs/advises on this (I'm personally hoping to have this feature very soon to use this for our services)

Hope that makes sense! 😸 