### PR TITLE
Align output of section-headers consistently

### DIFF
--- a/lib/exception_notifier/views/exception_notifier/background_exception_notification.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/background_exception_notification.text.erb
@@ -3,12 +3,12 @@
   <%= @exception.message %>
   <%= @backtrace.first %>
 
-  <%  sections = @sections.map do |section|
-        summary = render(section).strip
-        unless summary.blank?
-          title = render("title", :title => section).strip
-          "#{title}\n\n#{summary.gsub(/^/, "  ")}\n\n"
-        end
-      end.join
-  %>
-  <%= raw sections %>
+<%  sections = @sections.map do |section|
+      summary = render(section).strip
+      unless summary.blank?
+        title = render("title", :title => section).strip
+        "#{title}\n\n#{summary.gsub(/^/, "  ")}\n\n"
+      end
+    end.join
+%>
+<%= raw sections %>


### PR DESCRIPTION
Before, the header of the first section was prefixed by two spaces, 
leading to a visual disruption.

I took it upon myself to fix that.

Several things to keep in mind:

- This will - in all likelyhood - not end poverty, war or famine in general
- It only affects background notifications, the web-request notifications were good already
- Only text-mails are changed, since I couldn't be bothered to even look at ERB (also, we do not use the HTML-Notifications, so I cannot test it easily)
- target audience are people who prefer proper indendation in text-mails, YMMV.
- this patch is offered free of charge and conditions and - in the spirit of the MIT-License - without any obligation to end poverty, war or famine. But I started with that, didn't I?

I hereby kindly request that you pull my change into the project and release it as a new version.