### PR TITLE
Show the full chain of exceptions and backtraces if it's available

### DIFF
--- a/lib/exception_notifier/email_notifier.rb
+++ b/lib/exception_notifier/email_notifier.rb
@@ -38,6 +38,7 @@ module ExceptionNotifier
             @sections   = @options[:sections]
             @data       = (env['exception_notifier.exception_data'] || {}).merge(options[:data] || {})
             @sections   = @sections + %w(data) unless @data.empty?
+            @cause_exceptions = extract_cause_exceptions(exception)
 
             compose_email
           end
@@ -52,6 +53,7 @@ module ExceptionNotifier
             @sections  = @options[:background_sections]
             @data      = options[:data] || {}
             @env = @kontroller = nil
+            @cause_exceptions = extract_cause_exceptions(exception)
 
             compose_email
           end
@@ -131,6 +133,17 @@ module ExceptionNotifier
 
           def maybe_call(maybe_proc)
             maybe_proc.respond_to?(:call) ? maybe_proc.call : maybe_proc
+          end
+
+          def extract_cause_exceptions(exception)
+            return {} unless exception.respond_to? :cause
+
+            {}.tap do |result|
+              ce = exception
+              while (ce = ce.cause)
+                result[ce] = ce.backtrace ? clean_backtrace(ce) : []
+              end
+            end
           end
         end
       end

--- a/lib/exception_notifier/views/exception_notifier/_backtrace.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/_backtrace.html.erb
@@ -1,3 +1,11 @@
 <pre style="font-size: 12px; padding: 10px; border: 1px solid #e1e1e8; background-color:#f5f5f5">
 <%= @backtrace.join("\n") %>
 </pre>
+<% @cause_exceptions.each_pair do |cause_exception, backtrace| %>
+
+Caused by:
+<%= cause_exception.message %>
+<pre style="font-size: 12px; padding: 10px; border: 1px solid #e1e1e8; background-color:#f5f5f5">
+  <%= raw backtrace.join("\n") %>
+</pre>
+<% end %>

--- a/lib/exception_notifier/views/exception_notifier/_backtrace.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/_backtrace.text.erb
@@ -1,1 +1,7 @@
 <%= raw @backtrace.join("\n") %>
+<% @cause_exceptions.each_pair do |cause_exception, backtrace| %>
+
+Caused by:
+<%= cause_exception.message %>
+<%= raw backtrace.join("\n") %>
+<% end %>


### PR DESCRIPTION
Starting from ruby 2.1 we can display the full chain of raised
exceptions with help of `Exception#cause`. It is very useful for some
cases when a piece of code rescue from one exception just to add
additional info and raise another exception.