### PR TITLE
Replacing hangover reference to Rails.cache with error_grouping_cache…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - "gem install bundler"
   - "bundle install --jobs=3 --retry=3"
   - "mkdir -p test/dummy/tmp/cache"
+  - "mkdir -p test/dummy/tmp/non_default_location"
 gemfile:
   - gemfiles/rails4_0.gemfile
   - gemfiles/rails4_1.gemfile

--- a/lib/exception_notifier/modules/error_grouping.rb
+++ b/lib/exception_notifier/modules/error_grouping.rb
@@ -52,7 +52,7 @@ module ExceptionNotifier
         else
           backtrace_based_key = "exception:#{Zlib.crc32("#{exception.class.name}\npath:#{exception.backtrace.try(:first)}")}"
 
-          if count = Rails.cache.read(backtrace_based_key)
+          if count = error_grouping_cache.read(backtrace_based_key)
             accumulated_errors_count = count + 1
             save_error_count(backtrace_based_key, accumulated_errors_count)
           else

--- a/test/exception_notifier/modules/error_grouping_test.rb
+++ b/test/exception_notifier/modules/error_grouping_test.rb
@@ -5,7 +5,7 @@ class ErrorGroupTest < ActiveSupport::TestCase
   setup do
     module TestModule
       include ExceptionNotifier::ErrorGrouping
-      @@error_grouping_cache = ActiveSupport::Cache::FileStore.new("test/dummy/tmp/cache")
+      @@error_grouping_cache = ActiveSupport::Cache::FileStore.new("test/dummy/tmp/non_default_location")
     end
 
     @exception = RuntimeError.new("ERROR")


### PR DESCRIPTION
… option. Also changing dummy cache path away from rails cache path as this was causing the tests to pass in spite of this bug.

Fixes #423 