### PR TITLE
Add Google Chats notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ---
 
-The Exception Notification gem provides a set of [notifiers](#notifiers) for sending notifications when errors occur in a Rack/Rails application. The built-in notifiers can deliver notifications by [email](#email-notifier), [Campfire](#campfire-notifier), [HipChat](#hipchat-notifier), [Slack](#slack-notifier), [Mattermost](#mattermost-notifier), [IRC](#irc-notifier) or via custom [WebHooks](#webhook-notifier).
+The Exception Notification gem provides a set of [notifiers](#notifiers) for sending notifications when errors occur in a Rack/Rails application. The built-in notifiers can deliver notifications by [email](#email-notifier), [Campfire](#campfire-notifier), [HipChat](#hipchat-notifier), [Slack](#slack-notifier), [Mattermost](#mattermost-notifier), [IRC](#irc-notifier), [Google Chat](#google-chat-notifier) or via custom [WebHooks](#webhook-notifier).
 
 There's a great [Railscast about Exception Notification](http://railscasts.com/episodes/104-exception-notifications-revised) you can see that may help you getting started.
 
@@ -90,6 +90,7 @@ ExceptionNotification relies on notifiers to deliver notifications when errors o
 * [IRC notifier](#irc-notifier)
 * [Slack notifier](#slack-notifier)
 * [Mattermost notifier](#mattermost-notifier)
+* [Google Chat notifier](#google-chat-notifier)
 * [WebHook notifier](#webhook-notifier)
 
 But, you also can easily implement your own [custom notifier](#custom-notifier).
@@ -723,6 +724,36 @@ Url of your gitlab or github with your organisation name for issue creation link
 
 Your application name used for issue creation link. Defaults to ``` Rails.application.class.parent_name.underscore```.
 
+### Google Chat Notifier
+
+Post notifications in a Google Chats channel via [incoming webhook](https://developers.google.com/hangouts/chat/how-tos/webhooks)
+
+Add the [HTTParty](https://github.com/jnunemaker/httparty) gem to your `Gemfile`:
+
+```ruby
+gem 'httparty'
+```
+
+To configure it, you **need** to set the `webhook_url` option.
+
+```ruby
+Rails.application.config.middleware.use ExceptionNotification::Rack,
+  :google_chat => {
+    :webhook_url => 'https://chat.googleapis.com/v1/spaces/XXXXXXXX/messages?key=YYYYYYYYYYYYY&token=ZZZZZZZZZZZZ'
+  }
+```
+
+##### webhook_url
+
+*String, required*
+
+The Incoming WebHook URL on Google Chats.
+
+##### app_name
+
+*String, optional*
+
+Your application name, shown in the notification. Defaults to `Rails.application.class.parent_name.underscore`.
 
 ### WebHook notifier
 

--- a/lib/exception_notifier.rb
+++ b/lib/exception_notifier.rb
@@ -17,6 +17,7 @@ module ExceptionNotifier
   autoload :IrcNotifier, 'exception_notifier/irc_notifier'
   autoload :SlackNotifier, 'exception_notifier/slack_notifier'
   autoload :MattermostNotifier, 'exception_notifier/mattermost_notifier'
+  autoload :GoogleChatNotifier, 'exception_notifier/google_chat_notifier'
 
   class UndefinedNotifierError < StandardError; end
 

--- a/lib/exception_notifier/google_chat_notifier.rb
+++ b/lib/exception_notifier/google_chat_notifier.rb
@@ -1,0 +1,136 @@
+require 'action_dispatch'
+require 'active_support/core_ext/time'
+
+module ExceptionNotifier
+  class GoogleChatNotifier
+    include ExceptionNotifier::BacktraceCleaner
+
+    class MissingController
+      def method_missing(*args, &block)
+      end
+    end
+
+    attr_accessor :httparty
+
+    def initialize(options = {})
+      super()
+      @default_options = options
+      @httparty = HTTParty
+    end
+
+    def call(exception, options = {})
+      @options = options.merge(@default_options)
+      @exception = exception
+      @backtrace = exception.backtrace ? clean_backtrace(exception) : nil
+
+      @env = @options.delete(:env)
+
+      @application_name = @options.delete(:app_name) || Rails.application.class.parent_name.underscore
+
+      @webhook_url = @options.delete(:webhook_url)
+      raise ArgumentError.new "You must provide 'webhook_url' parameter." unless @webhook_url
+
+      unless @env.nil?
+        @controller = @env['action_controller.instance'] || MissingController.new
+
+        request = ActionDispatch::Request.new(@env)
+
+        @request_items = { url: request.original_url,
+                           http_method: request.method,
+                           ip_address: request.remote_ip,
+                           parameters: request.filtered_parameters,
+                           timestamp: Time.current }
+      else
+        @controller = @request_items = nil
+      end
+
+
+      @options[:body] = payload.to_json
+      @options[:headers] ||= {}
+      @options[:headers].merge!({ 'Content-Type' => 'application/json' })
+
+      @httparty.post(@webhook_url, @options)
+    end
+
+    private
+
+    def payload
+      {
+        text: exception_text
+      }
+    end
+
+    def header
+      errors_count = @options[:accumulated_errors_count].to_i
+      text = ['']
+
+      text << "Application: *#{@application_name}*"
+      text << "#{errors_count > 1 ? errors_count : 'An'} *#{@exception.class}* occured" + if @controller then " in *#{controller_and_method}*." else "." end
+
+      text
+    end
+
+    def exception_text
+      text = []
+
+      text << header
+      text << ''
+
+      text << "⚠️ Error 500 in #{Rails.env} ⚠️"
+      text << "*#{@exception.message.gsub('`', %q('))}*"
+
+      if @request_items
+        text << ''
+        text += message_request
+      end
+
+      if @backtrace
+        text << ''
+        text += message_backtrace
+      end
+
+      text.join("\n")
+    end
+
+    def message_request
+      text = []
+
+      text << "*Request:*"
+      text << "```"
+      text << hash_presentation(@request_items)
+      text << "```"
+
+      text
+    end
+
+    def hash_presentation(hash)
+      text = []
+
+      hash.each do |key, value|
+        text << "* #{key} : #{value}"
+      end
+
+      text.join("\n")
+    end
+
+    def message_backtrace(size = 3)
+      text = []
+
+      size = @backtrace.size < size ? @backtrace.size : size
+      text << "*Backtrace:*"
+      text << "```"
+      size.times { |i| text << "* " + @backtrace[i] }
+      text << "```"
+
+      text
+    end
+
+    def controller_and_method
+      if @controller
+        "#{@controller.controller_name}##{@controller.action_name}"
+      else
+        ""
+      end
+    end
+  end
+end

--- a/test/exception_notifier/google_chat_notifier_test.rb
+++ b/test/exception_notifier/google_chat_notifier_test.rb
@@ -1,0 +1,128 @@
+require 'test_helper'
+require 'httparty'
+
+class GoogleChatNotifierTest < ActiveSupport::TestCase
+
+  test "should send notification if properly configured" do
+    options = {
+      :webhook_url => 'http://localhost:8000'
+    }
+    google_chat_notifier = ExceptionNotifier::GoogleChatNotifier.new
+    google_chat_notifier.httparty = FakeHTTParty.new
+
+    options = google_chat_notifier.call ArgumentError.new("foo"), options
+
+    body = ActiveSupport::JSON.decode options[:body]
+    assert body.has_key? 'text'
+
+    text = body['text'].split("\n")
+    assert_equal 6, text.size
+    assert_equal 'Application: *dummy*', text[1]
+    assert_equal 'An *ArgumentError* occured.', text[2]
+    assert_equal '*foo*', text[5]
+  end
+
+  test "should use 'An' for exceptions count if :accumulated_errors_count option is nil" do
+    google_chat_notifier = ExceptionNotifier::GoogleChatNotifier.new
+    exception = ArgumentError.new("foo")
+    google_chat_notifier.instance_variable_set(:@exception, exception)
+    google_chat_notifier.instance_variable_set(:@options, {})
+
+    assert_includes google_chat_notifier.send(:header), "An *ArgumentError* occured."
+  end
+
+  test "shoud use direct errors count if :accumulated_errors_count option is 5" do
+    google_chat_notifier = ExceptionNotifier::GoogleChatNotifier.new
+    exception = ArgumentError.new("foo")
+    google_chat_notifier.instance_variable_set(:@exception, exception)
+    google_chat_notifier.instance_variable_set(:@options, { accumulated_errors_count: 5 })
+
+    assert_includes google_chat_notifier.send(:header), "5 *ArgumentError* occured."
+  end
+
+  test "Message request should be formatted as hash" do
+    google_chat_notifier = ExceptionNotifier::GoogleChatNotifier.new
+    request_items = { url: 'http://test.address',
+                      http_method: :get,
+                      ip_address: '127.0.0.1',
+                      parameters: '{"id"=>"foo"}',
+                      timestamp: Time.parse('2018-08-13 12:13:24 UTC') }
+    google_chat_notifier.instance_variable_set(:@request_items, request_items)
+
+    message_request =  google_chat_notifier.send(:message_request).join("\n")
+    assert_includes message_request, '* url : http://test.address'
+    assert_includes message_request, '* http_method : get'
+    assert_includes message_request, '* ip_address : 127.0.0.1'
+    assert_includes message_request, '* parameters : {"id"=>"foo"}'
+    assert_includes message_request, '* timestamp : 2018-08-13 12:13:24 UTC'
+  end
+
+  test 'backtrace with less than 3 lines should be displayed fully' do
+    google_chat_notifier = ExceptionNotifier::GoogleChatNotifier.new
+
+    backtrace = ["app/controllers/my_controller.rb:53:in `my_controller_params'", "app/controllers/my_controller.rb:34:in `update'"]
+    google_chat_notifier.instance_variable_set(:@backtrace, backtrace)
+
+    message_backtrace =  google_chat_notifier.send(:message_backtrace).join("\n")
+    assert_includes message_backtrace, "* app/controllers/my_controller.rb:53:in `my_controller_params'"
+    assert_includes message_backtrace, "* app/controllers/my_controller.rb:34:in `update'"
+  end
+
+  test 'backtrace with more than 3 lines should display only top 3 lines' do
+    google_chat_notifier = ExceptionNotifier::GoogleChatNotifier.new
+
+    backtrace = ["app/controllers/my_controller.rb:99:in `specific_function'", "app/controllers/my_controller.rb:70:in `specific_param'", "app/controllers/my_controller.rb:53:in `my_controller_params'", "app/controllers/my_controller.rb:34:in `update'"]
+    google_chat_notifier.instance_variable_set(:@backtrace, backtrace)
+
+    message_backtrace =  google_chat_notifier.send(:message_backtrace).join("\n")
+    assert_includes message_backtrace, "* app/controllers/my_controller.rb:99:in `specific_function'"
+    assert_includes message_backtrace, "* app/controllers/my_controller.rb:70:in `specific_param'"
+    assert_includes message_backtrace, "* app/controllers/my_controller.rb:53:in `my_controller_params'"
+    assert_not_includes message_backtrace, "* app/controllers/my_controller.rb:34:in `update'"
+  end
+
+  test 'Get text with backtrace and request info' do
+    google_chat_notifier = ExceptionNotifier::GoogleChatNotifier.new
+
+    backtrace = ["app/controllers/my_controller.rb:53:in `my_controller_params'", "app/controllers/my_controller.rb:34:in `update'"]
+    google_chat_notifier.instance_variable_set(:@backtrace, backtrace)
+
+    request_items = { url: 'http://test.address',
+                      http_method: :get,
+                      ip_address: '127.0.0.1',
+                      parameters: '{"id"=>"foo"}',
+                      timestamp: Time.parse('2018-08-13 12:13:24 UTC') }
+    google_chat_notifier.instance_variable_set(:@request_items, request_items)
+
+    google_chat_notifier.instance_variable_set(:@options, {accumulated_errors_count: 0})
+
+    google_chat_notifier.instance_variable_set(:@application_name, 'dummy')
+
+    exception = ArgumentError.new("foo")
+    google_chat_notifier.instance_variable_set(:@exception, exception)
+
+    text = google_chat_notifier.send(:exception_text)
+    expected_text = %q(
+Application: *dummy*
+An *ArgumentError* occured.
+
+⚠️ Error 500 in test ⚠️
+*foo*
+
+*Request:*
+```
+* url : http://test.address
+* http_method : get
+* ip_address : 127.0.0.1
+* parameters : {"id"=>"foo"}
+* timestamp : 2018-08-13 12:13:24 UTC
+```
+
+*Backtrace:*
+```
+* app/controllers/my_controller.rb:53:in `my_controller_params'
+* app/controllers/my_controller.rb:34:in `update'
+```)
+    assert_equal text, expected_text
+  end
+end


### PR DESCRIPTION
This commit adds Google Chats notifier by using the incoming webhooks.
Implementation is based off the mattermost implementation.