### PR TITLE
Updates incorrect text in Teams section referring to Mattermost

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,7 +829,7 @@ Rails.application.config.middleware.use ExceptionNotification::Rack,
 
 *String, required*
 
-The Incoming WebHook URL on mattermost.
+The Incoming WebHook URL on Teams.
 
 ##### git_url
 


### PR DESCRIPTION
Small text change to fix incorrect reference to Mattermost in the Teams section of README.md