### PR TITLE
Refactor Google Chat Notifier

### DIFF
--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "slack-notifier", ">= 1.0.0"
   s.add_development_dependency "aws-sdk-sns", "~> 1"
   s.add_development_dependency "dogapi", ">= 1.23.0"
-  s.add_development_dependency "timecop", "~>0.8.0"
+  s.add_development_dependency "timecop", "~>0.9.0"
 end

--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "slack-notifier", ">= 1.0.0"
   s.add_development_dependency "aws-sdk-sns", "~> 1"
   s.add_development_dependency "dogapi", ">= 1.23.0"
+  s.add_development_dependency "timecop", "~>0.8.0"
 end

--- a/lib/exception_notifier/google_chat_notifier.rb
+++ b/lib/exception_notifier/google_chat_notifier.rb
@@ -1,135 +1,100 @@
 require 'action_dispatch'
 require 'active_support/core_ext/time'
+require 'httparty'
 
 module ExceptionNotifier
-  class GoogleChatNotifier
+  class GoogleChatNotifier < BaseNotifier
     include ExceptionNotifier::BacktraceCleaner
 
-    class MissingController
-      def method_missing(*args, &block)
-      end
-    end
-
-    attr_accessor :httparty
-
-    def initialize(options = {})
-      super()
-      @default_options = options
-      @httparty = HTTParty
-    end
-
-    def call(exception, options = {})
-      @options = options.merge(@default_options)
+    def call(exception, opts = {})
+      @options = base_options.merge(opts)
       @exception = exception
-      @backtrace = exception.backtrace ? clean_backtrace(exception) : nil
 
-      @env = @options.delete(:env)
-
-      @application_name = @options.delete(:app_name) || Rails.application.class.parent_name.underscore
-
-      @webhook_url = @options.delete(:webhook_url)
-      raise ArgumentError.new "You must provide 'webhook_url' parameter." unless @webhook_url
-
-      unless @env.nil?
-        @controller = @env['action_controller.instance'] || MissingController.new
-
-        request = ActionDispatch::Request.new(@env)
-
-        @request_items = { url: request.original_url,
-                           http_method: request.method,
-                           ip_address: request.remote_ip,
-                           parameters: request.filtered_parameters,
-                           timestamp: Time.current }
-      else
-        @controller = @request_items = nil
-      end
-
-
-      @options[:body] = payload.to_json
-      @options[:headers] ||= {}
-      @options[:headers].merge!({ 'Content-Type' => 'application/json' })
-
-      @httparty.post(@webhook_url, @options)
+      HTTParty.post(
+        options[:webhook_url],
+        body: { text: body }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
     end
 
     private
 
-    def payload
-      {
-        text: exception_text
-      }
+    attr_reader :options, :exception
+
+    def body
+      text = [
+        header,
+        "",
+        "⚠️ Error 500 in #{Rails.env} ⚠️",
+        "*#{exception.message.tr('`', "'")}*"
+      ]
+
+      text += message_request
+      text += message_backtrace
+
+      text.join("\n")
     end
 
     def header
-      errors_count = @options[:accumulated_errors_count].to_i
-      text = ['']
+      text = ["\nApplication: *#{app_name}*"]
 
-      text << "Application: *#{@application_name}*"
-      text << "#{errors_count > 1 ? errors_count : 'An'} *#{@exception.class}* occured" + if @controller then " in *#{controller_and_method}*." else "." end
+      errors_text = errors_count > 1 ? errors_count : 'An'
+      text << "#{errors_text} *#{exception.class}* occured#{controller_text}."
 
       text
-    end
-
-    def exception_text
-      text = []
-
-      text << header
-      text << ''
-
-      text << "⚠️ Error 500 in #{Rails.env} ⚠️"
-      text << "*#{@exception.message.gsub('`', %q('))}*"
-
-      if @request_items
-        text << ''
-        text += message_request
-      end
-
-      if @backtrace
-        text << ''
-        text += message_backtrace
-      end
-
-      text.join("\n")
     end
 
     def message_request
-      text = []
+      return [] unless (env = options[:env])
+      request = ActionDispatch::Request.new(env)
 
-      text << "*Request:*"
-      text << "```"
-      text << hash_presentation(@request_items)
-      text << "```"
-
-      text
+      [
+        "",
+        "*Request:*",
+        "```",
+        "* url : #{request.original_url}",
+        "* http_method : #{request.method}",
+        "* ip_address : #{request.remote_ip}",
+        "* parameters : #{request.filtered_parameters}",
+        "* timestamp : #{Time.current}",
+        "```"
+      ]
     end
 
-    def hash_presentation(hash)
+    def message_backtrace
+      backtrace = exception.backtrace ? clean_backtrace(exception) : nil
+
+      return [] unless backtrace
+
       text = []
 
-      hash.each do |key, value|
-        text << "* #{key} : #{value}"
-      end
-
-      text.join("\n")
-    end
-
-    def message_backtrace(size = 3)
-      text = []
-
-      size = @backtrace.size < size ? @backtrace.size : size
+      text << ''
       text << "*Backtrace:*"
       text << "```"
-      size.times { |i| text << "* " + @backtrace[i] }
+      backtrace.first(3).each { |line| text << "* #{line}" }
       text << "```"
 
       text
     end
 
-    def controller_and_method
-      if @controller
-        "#{@controller.controller_name}##{@controller.action_name}"
-      else
-        ""
+    def app_name
+      @app_name ||= options[:app_name] || rails_app_name || "N/A"
+    end
+
+    def errors_count
+      @errors_count ||= options[:accumulated_errors_count].to_i
+    end
+
+    def rails_app_name
+      Rails.application.class.parent_name.underscore if defined?(Rails)
+    end
+
+    def controller_text
+      env = options[:env]
+      controller = env ? env['action_controller.instance'] : nil
+
+      if controller
+        " in *#{controller.controller_name}##{controller.action_name}*"
       end
     end
   end

--- a/test/exception_notifier/google_chat_notifier_test.rb
+++ b/test/exception_notifier/google_chat_notifier_test.rb
@@ -27,15 +27,14 @@ class GoogleChatNotifierTest < ActiveSupport::TestCase
       body
     ].join("\n")
 
-    opts = post_opts(text, accumulated_errors_count: 5)
-    HTTParty.expects(:post).with(URL, opts)
+    HTTParty.expects(:post).with(URL, post_opts(text))
 
     notifier.call(ArgumentError.new('foo'), accumulated_errors_count: 5)
   end
 
   test 'Message request should be formatted as hash' do
     text = [
-      header(true),
+      header,
       body,
       '',
       '*Request:*',
@@ -104,7 +103,7 @@ class GoogleChatNotifierTest < ActiveSupport::TestCase
 
   test 'Get text with backtrace and request info' do
     text = [
-      header(true),
+      header,
       body,
       '',
       '*Request:*',
@@ -140,11 +139,11 @@ class GoogleChatNotifierTest < ActiveSupport::TestCase
     ExceptionNotifier::GoogleChatNotifier.new(webhook_url: URL)
   end
 
-  def post_opts(text, opts = {})
+  def post_opts(text)
     {
       body: { text: text }.to_json,
       headers: { 'Content-Type' => 'application/json' }
-    }.merge(opts)
+    }
   end
 
   def test_env
@@ -157,11 +156,11 @@ class GoogleChatNotifierTest < ActiveSupport::TestCase
     )
   end
 
-  def header(env = false)
+  def header
     [
       '',
       'Application: *dummy*',
-      "An *ArgumentError* occured#{' in *#*' if env}.",
+      "An *ArgumentError* occured.",
       ''
     ].join("\n")
   end


### PR DESCRIPTION
Trying to make it more readable and maintainable.
I think there's a slight change in behavior: before it was passing all unknown options to HTTParty, now it is explicitly calling it only with `body` and `headers` (feels safer to do it this way)