### PR TITLE
Fix 'ActionMailer configured' link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Rails.application.config.middleware.use ExceptionNotification::Rack,
   }
 ```
 
-**Note**: In order to enable delivery notifications by email make sure you have [ActionMailer configured](#actionmailer-configuration).
+**Note**: In order to enable delivery notifications by email make sure you have [ActionMailer configured](docs/notifiers/email.md#actionmailer-configuration).
 
 ### Rack/Sinatra
 


### PR DESCRIPTION
'ActionMailer configured' links to #actionmailer-configuration but leads nowhere. Added link to action mailer configuration: https://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration