### PR TITLE
Fix datadog notifier appends previous errors

### DIFF
--- a/lib/exception_notifier/datadog_notifier.rb
+++ b/lib/exception_notifier/datadog_notifier.rb
@@ -76,7 +76,8 @@ module ExceptionNotifier
       end
 
       def formatted_title
-        title = title_prefix
+        title = ""
+        title << title_prefix
         title << "#{controller.controller_name} #{controller.action_name}" if controller
         title << " (#{exception.class})"
         title << " #{exception.message.inspect}"

--- a/test/exception_notifier/datadog_notifier_test.rb
+++ b/test/exception_notifier/datadog_notifier_test.rb
@@ -27,6 +27,20 @@ class DatadogNotifierTest < ActiveSupport::TestCase
     assert_includes event.msg_title, "FakeException"
   end
 
+  test "should include prefix in event title and not append previous events" do
+    options = {
+      client: @client,
+      title_prefix: "prefix"
+    }
+
+    notifier = ExceptionNotifier::DatadogNotifier.new(options)
+    event = notifier.datadog_event(@exception)
+    assert_equal event.msg_title, "prefix (DatadogNotifierTest::FakeException) \"Fake exception message\""
+
+    event2 = notifier.datadog_event(@exception)
+    assert_equal event2.msg_title, "prefix (DatadogNotifierTest::FakeException) \"Fake exception message\""
+  end
+
   test "should include exception message in event title" do
     event = @notifier.datadog_event(@exception)
     assert_includes event.msg_title, "Fake exception message"


### PR DESCRIPTION
This PR fixes datadog notifier to prevent appending the previous messages when using a prefix