### PR TITLE
Fix resque

### DIFF
--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "aws-sdk-sns", "~> 1"
   s.add_development_dependency "dogapi", ">= 1.23.0"
   s.add_development_dependency "timecop", "~>0.9.0"
+  s.add_development_dependency "mock_redis", "~> 0.19.0"
 end

--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency("activesupport", ">= 4.0", "< 6")
 
   s.add_development_dependency "rails", ">= 4.0", "< 6"
-  s.add_development_dependency "resque", "~> 1.2.0"
+  s.add_development_dependency "resque", "~> 1.8.0"
   # Sidekiq 3.2.2 does not support Ruby 1.9.
   s.add_development_dependency "sidekiq", "~> 3.0.0", "< 3.2.2"
   s.add_development_dependency "tinder", "~> 1.8"

--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "aws-sdk-sns", "~> 1"
   s.add_development_dependency "dogapi", ">= 1.23.0"
   s.add_development_dependency "timecop", "~>0.9.0"
-  s.add_development_dependency "mock_redis", "~> 0.19.0"
+  s.add_development_dependency "mock_redis", "~> 0.18.0"
 end

--- a/lib/exception_notification/resque.rb
+++ b/lib/exception_notification/resque.rb
@@ -9,7 +9,7 @@ module ExceptionNotification
     def save
       data = {
         error_class: exception.class.name,
-        error_message: exception.message
+        error_message: exception.message,
         failed_at: Time.now.to_s,
         payload: payload,
         queue: queue,

--- a/lib/exception_notification/resque.rb
+++ b/lib/exception_notification/resque.rb
@@ -3,7 +3,7 @@ require 'resque/failure/base'
 module ExceptionNotification
   class Resque < Resque::Failure::Base
     def self.count
-      Stat[:failed]
+      ::Resque::Stat[:failed]
     end
 
     def save

--- a/test/exception_notification/resque_test.rb
+++ b/test/exception_notification/resque_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+require "exception_notification/resque"
+require "resque"
+require "mock_redis"
+require 'resque/failure/multiple'
+require 'resque/failure/redis'
+
+class ResqueTest < ActiveSupport::TestCase
+  setup do
+    # Resque.redis=() only supports a String or Redis instance in Resque 1.8
+    Resque.instance_variable_set(:@redis, MockRedis.new)
+
+    Resque::Failure::Multiple.classes = [Resque::Failure::Redis, ExceptionNotification::Resque]
+    Resque::Failure.backend = Resque::Failure::Multiple
+
+    @worker = Resque::Worker.new(:jobs)
+    # Forking causes issues with Mocha's `.expects`
+    @worker.cant_fork = true
+  end
+
+  test "notifies exception when job fails" do
+    ExceptionNotifier.expects(:notify_exception).with() do |ex, opts|
+      RuntimeError === ex &&
+        ex.message == "Bad job!" &&
+        opts[:data][:resque][:error_class] == "RuntimeError" &&
+        opts[:data][:resque][:error_message] == "Bad job!" &&
+        opts[:data][:resque][:failed_at].present? &&
+        opts[:data][:resque][:payload] == {
+          "class" => "ResqueTest::BadJob",
+          "args" => []
+        } &&
+        opts[:data][:resque][:queue] == :jobs &&
+        opts[:data][:resque][:worker].present?
+    end
+
+    Resque::Job.create(:jobs, BadJob)
+    @worker.work(0)
+  end
+
+  class BadJob
+    def self.perform
+      raise "Bad job!"
+    end
+  end
+end

--- a/test/exception_notification/resque_test.rb
+++ b/test/exception_notification/resque_test.rb
@@ -19,6 +19,12 @@ class ResqueTest < ActiveSupport::TestCase
     @worker.cant_fork = true
   end
 
+  test "count returns the number of failures" do
+    Resque::Job.create(:jobs, BadJob)
+    @worker.work(0)
+    assert_equal 1, ExceptionNotification::Resque.count
+  end
+
   test "notifies exception when job fails" do
     ExceptionNotifier.expects(:notify_exception).with() do |ex, opts|
       RuntimeError === ex &&


### PR DESCRIPTION
There was a syntax error in the resque failure backend, and no tests for that file.