### PR TITLE
Use backtrace cleaner for Slack notifications

### DIFF
--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -50,7 +50,8 @@ module ExceptionNotifier
 
     def attchs(exception, clean_message, options)
       text, data = information_from_options(exception.class, options)
-      fields = fields(clean_message, exception.backtrace, data)
+      backtrace = clean_backtrace(exception) if exception.backtrace
+      fields = fields(clean_message, backtrace, data)
 
       [color: @color, text: text, fields: fields, mrkdwn_in: %w[text fields]]
     end


### PR DESCRIPTION
In https://github.com/smartinez87/exception_notification/pull/299, the backtrace formatting for Slack notifications was refactored. However, the use of the `BacktraceCleaner` has been forgotten in the transition. Slack notifications are currently using the raw backtrace, making them quite unreadable when the error is raised by a library:
![image](https://user-images.githubusercontent.com/425209/51438964-b3a26980-1cb3-11e9-943a-76cc5bbdad4b.png)

This PR restores the use of the backtrace cleaner for Slack notifications, the same way it's done in other Notifiers.

Tests for Slack notifications have been updated to reflect this change.