### PR TITLE
Add sample application to check for exception notification errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.gemfile.lock
 /Gemfile.lock
 /.idea/
+sample_app.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,24 @@ need contributors to follow:
     like OS version, gem versions, etc...
   * Even better, provide a failing test case for it.
 
+To help you add information to an issue, you can use the sample_app.
+Steps to use sample_app:
+
+1) Add your configuration to (ex. with webhook):
+```ruby
+config.middleware.use ExceptionNotification::Rack,
+  # -----------------------------------
+  # Change this with your configuration
+  # https://github.com/smartinez87/exception_notification#notifiers
+                        webhook: {
+                          url: 'http://domain.com:5555/hubot/path'
+                        }
+  # -----------------------------------
+```
+
+2) Run `ruby examples/sample_app.rb`
+If exception notification is working OK, you'll see the message "'Raising exception!" and then "Working OK!" and should receive the notification as configured above. If it's not, you can copy the information printed on the terminal related to exception notification and report an issue with more info!
+
 ## Pull Requests
 
 If you've gone the extra mile and have a patch that fixes the issue, you

--- a/examples/sample_app.rb
+++ b/examples/sample_app.rb
@@ -14,13 +14,9 @@ end
 
 class SampleApp < Rails::Application
   config.middleware.use ExceptionNotification::Rack,
-  # -----------------------------------
-  # Change this with your configuration
-  # https://github.com/smartinez87/exception_notification#notifiers
                         webhook: {
                           url: 'http://domain.com:5555/hubot/path'
                         }
-  # -----------------------------------
 
   config.secret_key_base = 'my secret key base'
   file = File.open('sample_app.log', 'w')
@@ -51,7 +47,7 @@ class Test < Minitest::Test
 
   def test_raise_exception
     get '/raise_sample_exception'
-    puts "Working OK!"
+    puts 'Working OK!'
   end
 
   private

--- a/examples/sample_app.rb
+++ b/examples/sample_app.rb
@@ -1,5 +1,5 @@
 # -------------------------------------------
-# To run the application: ruby example/sample_app.rb
+# To run the application: ruby examples/sample_app.rb
 # -------------------------------------------
 
 require 'bundler/inline'

--- a/examples/sample_app.rb
+++ b/examples/sample_app.rb
@@ -1,5 +1,5 @@
 # -------------------------------------------
-# To run the application: ruby sample_app.rb
+# To run the application: ruby example/sample_app.rb
 # -------------------------------------------
 
 require 'bundler/inline'

--- a/sample_app.rb
+++ b/sample_app.rb
@@ -1,4 +1,7 @@
+# -------------------------------------------
 # To run the application: ruby sample_app.rb
+# -------------------------------------------
+
 require 'bundler/inline'
 
 gemfile do
@@ -12,7 +15,7 @@ end
 class SampleApp < Rails::Application
   config.middleware.use ExceptionNotification::Rack,
   # -----------------------------------
-  # Change this with the notifier you want to test
+  # Change this with your configuration
   # https://github.com/smartinez87/exception_notification#notifiers
                         webhook: {
                           url: 'http://domain.com:5555/hubot/path'

--- a/sample_app.rb
+++ b/sample_app.rb
@@ -23,11 +23,12 @@ class SampleApp < Rails::Application
   # -----------------------------------
 
   config.secret_key_base = 'my secret key base'
-  config.logger = Logger.new($stdout)
-  Rails.logger = config.logger
+  file = File.open('sample_app.log', 'w')
+  logger = Logger.new(file)
+  Rails.logger = logger
 
   routes.draw do
-    get 'raise_exception', to: 'exceptions#sample'
+    get 'raise_sample_exception', to: 'exceptions#raise_sample_exception'
   end
 end
 
@@ -37,7 +38,8 @@ require 'active_support'
 class ExceptionsController < ActionController::Base
   include Rails.application.routes.url_helpers
 
-  def sample
+  def raise_sample_exception
+    puts 'Raising exception!'
     raise 'Sample exception raised, you should receive a notification!'
   end
 end
@@ -48,7 +50,8 @@ class Test < Minitest::Test
   include Rack::Test::Methods
 
   def test_raise_exception
-    get '/raise_exception'
+    get '/raise_sample_exception'
+    puts "Working OK!"
   end
 
   private

--- a/sample_app.rb
+++ b/sample_app.rb
@@ -1,0 +1,56 @@
+# To run the application: ruby sample_app.rb
+require 'bundler/inline'
+
+gemfile do
+  source 'https://rubygems.org'
+
+  gem 'rails', '5.0.0'
+  gem 'exception_notification', '4.3.0'
+  gem 'httparty', '0.15.7'
+end
+
+class SampleApp < Rails::Application
+  config.middleware.use ExceptionNotification::Rack,
+  # -----------------------------------
+  # Change this with the notifier you want to test
+  # https://github.com/smartinez87/exception_notification#notifiers
+                        webhook: {
+                          url: 'http://domain.com:5555/hubot/path'
+                        }
+  # -----------------------------------
+
+  config.secret_key_base = 'my secret key base'
+  config.logger = Logger.new($stdout)
+  Rails.logger = config.logger
+
+  routes.draw do
+    get 'raise_exception', to: 'exceptions#sample'
+  end
+end
+
+require 'action_controller/railtie'
+require 'active_support'
+
+class ExceptionsController < ActionController::Base
+  include Rails.application.routes.url_helpers
+
+  def sample
+    raise 'Sample exception raised, you should receive a notification!'
+  end
+end
+
+require 'minitest/autorun'
+
+class Test < Minitest::Test
+  include Rack::Test::Methods
+
+  def test_raise_exception
+    get '/raise_exception'
+  end
+
+  private
+
+  def app
+    Rails.application
+  end
+end


### PR DESCRIPTION
Sample one file application to test exception notification. Copy information from terminal to report issues.

----------------------------------------------------------------------------------------

Steps to use:

1) Add the configuration to (use https://github.com/smartinez87/exception_notification#notifiers):
```ruby
config.middleware.use ExceptionNotification::Rack,
                             webhook: {
                               url: 'http://domain.com:5555/hubot/path'
                             }
```

2) Run `ruby example/sample_app.rb`
3) If exception notification is working OK, you'll see the message "'Raising exception!" and then "Working OK!" and receive the notification as configured above. If it's not, you can copy the information printed on the terminal related to the exception notification gem and report an issue with more info.

Notes:
- sample_app.log file related to https://github.com/rails/rails/issues/28968