### PR TITLE
CI Improvements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,5 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   TargetRubyVersion: 2.0
   DisplayCopNames: true
+  Exclude:
+    - "gemfiles/**/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ install:
   - "bundle install --jobs=3 --retry=3 --path=vendor/bundle"
   - "mkdir -p test/dummy/tmp/cache"
   - "mkdir -p test/dummy/tmp/non_default_location"
+script:
+  - bundle exec rake test
+  - bundle exec rubocop
 gemfile:
   - gemfiles/rails4_0.gemfile
   - gemfiles/rails4_1.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
   - 2.1.10
   - 2.2.9
@@ -12,7 +13,7 @@ before_install:
   - gem install bundler -v '< 2'
 
 install:
-  - "bundle install --jobs=3 --retry=3"
+  - "bundle install --jobs=3 --retry=3 --path=vendor/bundle"
   - "mkdir -p test/dummy/tmp/cache"
   - "mkdir -p test/dummy/tmp/non_default_location"
 gemfile:

--- a/Rakefile
+++ b/Rakefile
@@ -11,5 +11,5 @@ Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
   t.libs << 'test'
   t.pattern = 'test/**/*_test.rb'
-  t.verbose = true
+  t.warning = false
 end


### PR DESCRIPTION
Trying to improve how the CI runs:

1. Remove warnings and verbose logs when running `rake test` (also helps in local environments to reduce the noise)
1. Run rubocop on the CI, fail the build if there are rubocop offenses
1. Enable Travis bundler cache. Had to specify `--path=vendor/bundle` when running bundle install so Travis knows where the gems are stored. And since we run Appraisal it looks like the path is relative to `gemfiles/`, so I had to exclude the folder in Rubocop (maybe there's a better way to do this?)

You can take a look at these two builds to see the difference when caching:

https://travis-ci.org/EmilioCristalli/exception_notification/builds/483732102  (without cache, or actually only the first job was cached because in the previous build i only run the first job => Ran for 13 min 33 sec)

https://travis-ci.org/EmilioCristalli/exception_notification/builds/483735045 (with all jobs cached => Ran for 9 min 30 sec)