### PR TITLE
Add slack channel name override

### DIFF
--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -28,6 +28,8 @@ module ExceptionNotifier
 
       args = [exception, options, clean_message, @message_opts.merge(attachments: attchs)]
       send_notice(*args) do |_msg, message_opts|
+        message_opts[:channel] = options[:channel] if options.key?(:channel)
+
         @notifier.ping '', message_opts
       end
     end


### PR DESCRIPTION
- Update the `slacks.md` documentation to include:
  - The new `channel` option when callin
 `ExceptionNotifier.notify_exception`
  - the `:pre_callback` hook on the rack middleware, that allows to
 manipulate what's sent to the underlying slack notifier. In particular,
 this can append an option to the `#ping` slack notifier method. but
 you can pretty much do any manipulation right before sending the
 notification.

To make the API easier, the slack notifier for `ExceptionNotification`
now allows to override the default channel name, since it's an option that is
possible in the `slack-notifier` gem (and documented in their README)