### PR TITLE
Add support for third party notifiers

### DIFF
--- a/lib/exception_notifier.rb
+++ b/lib/exception_notifier.rb
@@ -127,8 +127,12 @@ module ExceptionNotifier
     end
 
     def create_and_register_notifier(name, options)
+      third_party_module = options[:third_party_module]
+      notifier_module = third_party_module ? third_party_module::ExceptionNotifier : ExceptionNotifier
+
       notifier_classname = "#{name}_notifier".camelize
-      notifier_class = ExceptionNotifier.const_get(notifier_classname)
+      notifier_class = notifier_module.const_get(notifier_classname)
+
       notifier = notifier_class.new(options)
       register_exception_notifier(name, notifier)
     rescue NameError => e


### PR DESCRIPTION
# Motivation
Currently, in order to add a new notifier, we just add the name `new_service` in the options and it loads the `ExceptionNotifier::NewServiceNotifier` class.

However, since gems are required to be wrapped in its own module, we need to add some changes in the code to support it.

# Proposal
Add a new field in options where the user can specify the name of the external library.
```ruby
Rails.application.config.middleware.use ExceptionNotification::Rack,
                                        email: {
                                          email_prefix: '[PREFIX] ',
                                          sender_address: %{"notifier" <notifier@example.com>},
                                          exception_recipients: %w{exceptions@example.com}
                                        },
                                        some_third_party_service: {
                                          ...
                                          third_party_module: ThirdPartyService,
                                          ...
                                        }
```

This will try to load the class `ThirdPartyService::ExceptionNotifier::SomeThirdPartyServiceNotifier`

# Disclaimer
I'm not sure it this is the best approach (it just works) so feedback to improve this solution is highly appreciated
