### PR TITLE
Fix email template error with Rails 6

### DIFF
--- a/lib/exception_notifier/views/exception_notifier/background_exception_notification.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/background_exception_notification.html.erb
@@ -9,14 +9,29 @@
 <%
   sections_content = @sections.map do |section|
     begin
-      summary = render(section).strip
+      summary = render(section)
+      if summary.respond_to? :body
+        summary = summary.body
+      end
+      summary.strip!
+
       unless summary.blank?
-        title = render("title", :title => section).strip
+        title = render("title", title: section)
+        if title.respond_to? :body
+          title = title.body
+        end
+        title.strip!
+
         [title, summary]
       end
 
     rescue Exception => e
-      title = render("title", :title => section).strip
+      title = render("title", title: section)
+      if title.respond_to? :body
+        title = title.body
+      end
+      title.strip!
+
       summary = ["ERROR: Failed to generate exception summary:", [e.class.to_s, e.message].join(": "), e.backtrace && e.backtrace.join("\n")].compact.join("\n\n")
 
       [title, summary]

--- a/lib/exception_notifier/views/exception_notifier/background_exception_notification.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/background_exception_notification.text.erb
@@ -4,10 +4,32 @@
   <%= @backtrace.first %>
 
 <%  sections = @sections.map do |section|
-      summary = render(section).strip
-      unless summary.blank?
-        title = render("title", :title => section).strip
-        "#{title}\n\n#{summary.gsub(/^/, "  ")}\n\n"
+      begin
+        summary = render(section)
+        if summary.respond_to? :body
+          summary = summary.body
+        end
+        summary.strip!
+
+        unless summary.blank?
+          title = render("title", title: section)
+          if title.respond_to? :body
+            title = title.body
+          end
+          title.strip!
+
+          "#{title}\n\n#{summary.gsub(/^/, "  ")}\n\n"
+        end
+      rescue Exception => e
+        title = render("title", title: section)
+        if title.respond_to? :body
+          title = title.body
+        end
+        title.strip!
+
+        summary = ["ERROR: Failed to generate exception summary:", [e.class.to_s, e.message].join(": "), e.backtrace && e.backtrace.join("\n")].compact.join("\n\n")
+
+        [title, summary.gsub(/^/, "  "), nil].join("\n\n")
       end
     end.join
 %>

--- a/lib/exception_notifier/views/exception_notifier/exception_notification.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/exception_notification.html.erb
@@ -9,13 +9,28 @@
 <%
   sections_content = @sections.map do |section|
     begin
-      summary = render(section).strip
+      summary = render(section)
+      if summary.respond_to? :body
+        summary = summary.body
+      end
+      summary.strip!
+
       unless summary.blank?
-        title = render("title", title: section).strip
+        title = render("title", title: section)
+        if title.respond_to? :body
+          title = title.body
+        end
+        title.strip!
+
         [title, summary]
       end
     rescue Exception => e
-      title = render("title", title: section).strip
+      title = render("title", title: section)
+      if title.respond_to? :body
+        title = title.body
+      end
+      title.strip!
+
       summary = ["ERROR: Failed to generate exception summary:", [e.class.to_s, e.message].join(": "), e.backtrace && e.backtrace.join("\n")].compact.join("\n\n")
       [title, summary]
     end

--- a/lib/exception_notifier/views/exception_notifier/exception_notification.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/exception_notification.text.erb
@@ -6,14 +6,29 @@
 <%
     sections = @sections.map do |section|
       begin
-        summary = render(section).strip
+        summary = render(section)
+        if summary.respond_to? :body
+          summary = summary.body
+        end
+        summary.strip!
+
         unless summary.blank?
-          title = render("title", title: section).strip
+          title = render("title", title: section)
+          if title.respond_to? :body
+            title = title.body
+          end
+          title.strip!
+
           "#{title}\n\n#{summary.gsub(/^/, "  ")}\n\n"
         end
 
       rescue Exception => e
-        title = render("title", title: section).strip
+        title = render("title", title: section)
+        if title.respond_to? :body
+          title = title.body
+        end
+        title.strip!
+
         summary = ["ERROR: Failed to generate exception summary:", [e.class.to_s, e.message].join(": "), e.backtrace && e.backtrace.join("\n")].compact.join("\n\n")
 
         [title, summary.gsub(/^/, "  "), nil].join("\n\n")


### PR DESCRIPTION
Resolves an error due to `#render` returning an `ActionView::AbstractRenderer::RenderedTemplate` in Rails 6 rather than a String. `RenderedTemplate` does not respond to String methods, so we need to get its body (the String content) before calling `#strip`.

The error message:
> An error occurred when sending a notification using 'email' notifier. ActionView::Template::Error: undefined method `strip' for #<ActionView::AbstractRenderer::RenderedTemplate:0x0000000003c730f0>

This PR is set up to check for the existence of `#body` before calling it, to maintain compatibility with Rails versions <6.