### PR TITLE
Run RuboCop only once per CI run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,7 @@ install:
   - "bundle install --jobs=3 --retry=3 --path=vendor/bundle"
   - "mkdir -p test/dummy/tmp/cache"
   - "mkdir -p test/dummy/tmp/non_default_location"
-script:
-  - bundle exec rake test
-  - bundle exec rubocop
+
 gemfile:
   - gemfiles/rails4_0.gemfile
   - gemfiles/rails4_1.gemfile
@@ -27,6 +25,7 @@ gemfile:
   - gemfiles/rails5_1.gemfile
   - gemfiles/rails5_2.gemfile
   - gemfiles/rails6_0.gemfile
+
 matrix:
   exclude:
     - rvm: 2.1.10
@@ -52,3 +51,9 @@ matrix:
       gemfile: gemfiles/rails4_0.gemfile
     - rvm: 2.5.0
       gemfile: gemfiles/rails4_1.gemfile
+
+jobs:
+  include:
+    - stage: Lint
+      rvm: 2.6.4
+      script: bundle exec rubocop


### PR DESCRIPTION
Right now, RuboCop is called for every job in the CI matrix, however
there should never be a different result, depending on Ruby or Rails
version.

So we only run RuboCop once, in a Lint stage.

The `script` part was removed as the default is `bundle exec rake` which
is the same as `bundle exec rake test` in the case of this gem.