### PR TITLE
Bugfix - Add exception_data to Mattermost notifier message

### DIFF
--- a/lib/exception_notifier/mattermost_notifier.rb
+++ b/lib/exception_notifier/mattermost_notifier.rb
@@ -56,7 +56,7 @@ module ExceptionNotifier
         text << backtrace
       end
 
-      if (exception_data = @env["exception_notifier.exception_data"])
+      if (exception_data = @env['exception_notifier.exception_data'])
         text << '### Data'
         data_string = exception_data.map { |k, v| "* #{k} : #{v}" }.join("\n")
         text << "```\n#{data_string}\n```"

--- a/lib/exception_notifier/mattermost_notifier.rb
+++ b/lib/exception_notifier/mattermost_notifier.rb
@@ -12,6 +12,8 @@ module ExceptionNotifier
 
       @gitlab_url = options[:git_url]
 
+      @env = options[:env] || {}
+
       payload = {
         text: message_text.compact.join("\n"),
         username: options[:username] || 'Exception Notifier'
@@ -52,6 +54,12 @@ module ExceptionNotifier
       if (backtrace = formatter.backtrace_message.presence)
         text << '### Backtrace'
         text << backtrace
+      end
+
+      if (exception_data = @env["exception_notifier.exception_data"])
+        text << '### Data'
+        data_string = exception_data.map { |k, v| "* #{k} : #{v}" }.join("\n")
+        text << "```\n#{data_string}\n```"
       end
 
       text << message_issue_link if @gitlab_url

--- a/test/exception_notifier/mattermost_notifier_test.rb
+++ b/test/exception_notifier/mattermost_notifier_test.rb
@@ -140,6 +140,31 @@ class MattermostNotifierTest < ActiveSupport::TestCase
     notifier.call(exception, env: test_env)
   end
 
+  test 'should include exception_data_info' do
+    body = default_body.merge(
+      text: [
+        '@channel',
+        error_occurred_in,
+        'An *ArgumentError* occurred.',
+        '*foo*',
+        request_info,
+        exception_data_info
+      ].join("\n")
+    )
+
+    opts = {
+      body: body.to_json,
+      headers: default_headers
+    }
+
+    env = test_env.merge(
+      'exception_notifier.exception_data' => { foo: 'bar', john: 'doe' }
+    )
+
+    HTTParty.expects(:post).with(URL, opts)
+    notifier.call(ArgumentError.new('foo'), env: env)
+  end
+
   private
 
   def notifier
@@ -210,6 +235,16 @@ class MattermostNotifierTest < ActiveSupport::TestCase
       '```',
       "* app/controllers/my_controller.rb:53:in `my_controller_params'",
       "* app/controllers/my_controller.rb:34:in `update'",
+      '```'
+    ]
+  end
+
+  def exception_data_info
+    [
+      '### Data',
+      '```',
+      '* foo : bar',
+      '* john : doe',
       '```'
     ]
   end


### PR DESCRIPTION
Fixes #490 

![image](https://user-images.githubusercontent.com/52419977/75567135-c7301000-5a2f-11ea-9a9d-3c39fee28665.png)
