### PR TITLE
Add Content-Type header to Slack notifier - req. for discord

### DIFF
--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -72,6 +72,9 @@ module ExceptionNotifier
       exception_name = "*#{measure_word}* `#{exception_class}`"
       env = options[:env]
 
+      options[:headers] ||= {}
+      options[:headers]['Content-Type'] = 'application/json'
+
       if env.nil?
         data = options[:data] || {}
         text = "#{exception_name} *occured in background*\n"


### PR DESCRIPTION
I was working on building `discord` webhook for this repo, then I came across [Discord - Slack Compatible Docs](https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook).

This means we can use `slack` notifier with Discord webhook(plus adding `/slack` at the end of discord webhook url). Ex:
```rb
config.add_notifier :slack, {
    webhook_url: "https://discord.com/api/webhooks/XXXX/XXXXXXXXX/slack"
  }
```

But the problem is, Discord webhooks requires header `Content-Type: application/json` set to it. This is pretty standard and recommended for all API apps. Seems that, for Slack API this header is optional, so right now the above discord webhook will fail.

So, I've just added the `Content-Type` header to the Slack Notifier, this will work for both Slack and Discord.