### PR TITLE
Restore controller action hash separator

### DIFF
--- a/lib/exception_notifier/email_notifier.rb
+++ b/lib/exception_notifier/email_notifier.rb
@@ -76,7 +76,7 @@ module ExceptionNotifier
           def compose_subject
             subject = @options[:email_prefix].to_s.dup
             subject << "(#{@options[:accumulated_errors_count]} times)" if @options[:accumulated_errors_count].to_i > 1
-            subject << "#{@kontroller.controller_name} #{@kontroller.action_name}" if include_controller?
+            subject << "#{@kontroller.controller_name}##{@kontroller.action_name}" if include_controller?
             subject << " (#{@exception.class})"
             subject << " #{@exception.message.inspect}" if @options[:verbose_subject]
             subject = EmailNotifier.normalize_digits(subject) if @options[:normalize_subject]

--- a/test/exception_notifier/email_notifier_test.rb
+++ b/test/exception_notifier/email_notifier_test.rb
@@ -248,7 +248,7 @@ class EmailNotifierWithEnvTest < ActiveSupport::TestCase
   test 'sends mail with correct content' do
     assert_equal %("Dummy Notifier" <dummynotifier@example.com>), @mail[:from].value
     assert_equal %w[dummyexceptions@example.com], @mail.to
-    assert_equal '[Dummy ERROR] home index (ZeroDivisionError) "divided by 0"', @mail.subject
+    assert_equal '[Dummy ERROR] home#index (ZeroDivisionError) "divided by 0"', @mail.subject
     assert_equal 'foobar', @mail['X-Custom-Header'].value
     assert_equal 'text/plain; charset=UTF-8', @mail.content_type
     assert_equal [], @mail.attachments


### PR DESCRIPTION
The removal of the separator was introduced in 9e7744087.

I believe this to be a regression, as do others in the Pull Request
comments [1].

Given the commit message, it doesn't appear that the author appreciated
the reasons behind the double hash.

Other specs assert that the controller and action name is separated by a
hash, not a space:

    $ grep -r "home#index" test
    test/exception_notifier/email_notifier_test.rb:    assert_equal '[Dummy ERROR] home#index (ZeroDivisionError) "divided by 0"', @mail.subject
    test/exception_notifier/email_notifier_test.rb:      A ZeroDivisionError occurred in home#index:
    test/exception_notifier/modules/formatter_test.rb:    assert_equal 'A *RuntimeError* occurred in *home#index*.', formatter.subtitle
    test/exception_notifier/modules/formatter_test.rb:    assert_equal 'home#index', formatter.controller_and_action

    $ grep -Er "#\{kontroller.controller_name\}##\{kontroller.action_name\}" test
    test/exception_notifier/slack_notifier_test.rb:      text += " *was processed by* `#{kontroller.controller_name}##{kontroller.action_name}`" if kontroller

The test for EmailNotifier was introduced nearly 2 years later in
eb173627, so the regression was not caught at the time. The test author
mirrored the incorrect behaviour, presumably to get some improved level
of coverage based on the existing code.

[1] https://github.com/smartinez87/exception_notification/pull/398