### PR TITLE
Added option clean_backtrace with default value true to SlackNotifier

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,3 +1,6 @@
+* enhancements
+  * Added `clean_backtrace` option to SlackNotifier (defaults to true).
+
 == 4.4.3
 
 * big fixes

--- a/docs/notifiers/slack.md
+++ b/docs/notifiers/slack.md
@@ -141,6 +141,12 @@ Message will appear in this channel. Defaults to the channel you set as such on 
 
 Username of the bot. Defaults to the name you set as such on slack
 
+##### clean_backtrace
+
+*Boolean, optional*
+
+If enabled will clean the exception backtrace with Rails.backtrace_cleaner. Defaults to true.
+
 ##### custom_hook
 
 *String, optional*

--- a/lib/exception_notifier/slack_notifier.rb
+++ b/lib/exception_notifier/slack_notifier.rb
@@ -11,6 +11,7 @@ module ExceptionNotifier
       begin
         @ignore_data_if = options[:ignore_data_if]
         @backtrace_lines = options.fetch(:backtrace_lines, 10)
+        @clean_backtrace = options.delete(:clean_backtrace) { true }
         @additional_fields = options[:additional_fields]
 
         webhook_url = options.fetch(:webhook_url)
@@ -54,7 +55,9 @@ module ExceptionNotifier
 
     def attchs(exception, clean_message, options)
       text, data = information_from_options(exception.class, options)
-      backtrace = clean_backtrace(exception) if exception.backtrace
+      backtrace = if exception.backtrace
+        @clean_backtrace ? clean_backtrace(exception) : exception.backtrace
+      end
       fields = fields(clean_message, backtrace, data)
 
       [color: @color, text: text, fields: fields, mrkdwn_in: %w[text fields]]

--- a/test/exception_notifier/slack_notifier_test.rb
+++ b/test/exception_notifier/slack_notifier_test.rb
@@ -76,7 +76,7 @@ class SlackNotifierTest < ActiveSupport::TestCase
     slack_notifier.call(@exception)
   end
 
-  test 'should send the notification withouth cleaned backtrace lines if option is false' do
+  test 'should send the notification without cleaned backtrace lines if option is false' do
     options = {
       webhook_url: 'http://slack.webhook.url',
       clean_backtrace: false


### PR DESCRIPTION
Hi! I know this has been previously addressed in #242 and #328 but was never merged.

So this is a way of scratching my own itch, just for the SlackNotifier which is the one I use.

Simple and to the point.