### PR TITLE
Ignore to set access_key_id & secret_access_key on AWS SNS Notifier

### DIFF
--- a/lib/exception_notifier/sns_notifier.rb
+++ b/lib/exception_notifier/sns_notifier.rb
@@ -5,14 +5,12 @@ module ExceptionNotifier
     def initialize(options)
       super
 
+      allowed_keys = %i[region access_key_id secret_access_key]
+
       raise ArgumentError, "You must provide 'region' option" unless options[:region]
-      raise ArgumentError, "You must provide 'access_key_id' option" unless options[:access_key_id]
-      raise ArgumentError, "You must provide 'secret_access_key' option" unless options[:secret_access_key]
 
       @notifier = Aws::SNS::Client.new(
-        region: options[:region],
-        access_key_id: options[:access_key_id],
-        secret_access_key: options[:secret_access_key]
+        **options.select { |k, _| allowed_keys.include?(k) }
       )
       @options = default_options.merge(options)
     end

--- a/test/exception_notifier/sns_notifier_test.rb
+++ b/test/exception_notifier/sns_notifier_test.rb
@@ -40,24 +40,6 @@ class SnsNotifierTest < ActiveSupport::TestCase
     assert_equal "You must provide 'region' option", error.message
   end
 
-  test 'should raise an exception on publish if access_key_id is not received' do
-    @options[:access_key_id] = nil
-    error = assert_raises ArgumentError do
-      ExceptionNotifier::SnsNotifier.new(@options)
-    end
-
-    assert_equal "You must provide 'access_key_id' option", error.message
-  end
-
-  test 'should raise an exception on publish if secret_access_key is not received' do
-    @options[:secret_access_key] = nil
-    error = assert_raises ArgumentError do
-      ExceptionNotifier::SnsNotifier.new(@options)
-    end
-
-    assert_equal "You must provide 'secret_access_key' option", error.message
-  end
-
   # call
 
   test 'should send a sns notification in background' do


### PR DESCRIPTION
Hi,
I suppressed ArgumentErrors, since I want to use IAM role based authentication.
https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html#aws-ruby-sdk-credentials-iam
