### PR TITLE
[DRAFT] Prepare for 4.5.0

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,3 +1,15 @@
+== 4.5.0
+
+* enhancements
+  * Added Rails 7 compatibility (by @fwininger)
+  * Added support for the optional `data` attribute to the SNS notifier (@TomK32)
+  * Addressed a deprecation warning for `module_parent_name` which was thrown for users
+    using Rails > 6.x (@quorak)
+  * Restored the hash separator for `controller#action` in the email notifier (@garethrees)
+
+* removals
+  * Dropped support for Tinder (gem is no longer maintained) (by @fwininger)
+
 == 4.4.3
 
 * big fixes

--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.name = 'exception_notification'
   s.version = ExceptionNotification::VERSION
   s.authors = ['Jamis Buck', 'Josh Peek']
-  s.date = '2020-06-29'
+  s.date = '2022-01-12'
   s.summary = 'Exception notification for Rails apps'
   s.homepage = 'https://smartinez87.github.io/exception_notification/'
   s.email = 'smartinez87@gmail.com'

--- a/lib/exception_notification/version.rb
+++ b/lib/exception_notification/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionNotification
-  VERSION = '4.4.3'
+  VERSION = '4.5.0'
 end


### PR DESCRIPTION
This pull request has a dependency on #523, because it assumes that support for Rails 7.x is already present in master at the time of merging.

* The changelog was adjusted to reflect all changes done between 4.4.3 up until now.
* The version number was bumped to 4.5.0. I personally think it makes sense to increase the minor version number instead of the patch level, because the next release will include support for Rails 7.x.

@smartinez87 I added you as a reviewer. Please give this PR a try when #523 is merged. (I need to rebase this PR when #523 is merged, because there will be a merge conflict in the gemspec file)