### PR TITLE
Exclude example directories from spec.files

### DIFF
--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = '>= 2.3'
   s.required_rubygems_version = '>= 1.8.11'
 
-  s.files = `git ls-files`.split("\n")
+  s.files = `git ls-files | grep -v '^examples'`.split("\n")
   s.files -= `git ls-files -- .??*`.split("\n")
   s.test_files = `git ls-files -- test`.split("\n")
   s.require_path = 'lib'


### PR DESCRIPTION
I fixed issue #528 !

 I exclude example directories from `spec.files`.

Thanks.