### PR TITLE
Add 'changelog_uri' to the gem metadata.

### DIFF
--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://smartinez87.github.io/exception_notification/'
   s.email = 'smartinez87@gmail.com'
   s.license = 'MIT'
+  s.metadata = { 'changelog_uri' => 'https://github.com/smartinez87/exception_notification/blob/master/CHANGELOG.rdoc' }
 
   s.required_ruby_version     = '>= 2.3'
   s.required_rubygems_version = '>= 1.8.11'


### PR DESCRIPTION
## What

Add `changelog_uri` to the gem metadata.

## Why

Changelog URLs have been valid [metadata](https://guides.rubygems.org/specification-reference/#metadata) since 2017 on RubyGems.org. Setting `changelog_uri` will add a "Changelog" link to the Rubygems page for exception_notification https://rubygems.org/gems/exception_notification/