### PR TITLE
Improve compatibility with frozen string literal

### DIFF
--- a/lib/exception_notifier/views/exception_notifier/_data.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/_data.html.erb
@@ -1,6 +1,6 @@
 <ul style="list-style: none">
   <li>
     <strong>data:</strong>
-    <span><%= PP.pp(@data, "") %></span>
+    <span><%= PP.pp(@data, +"") %></span>
   </li>
 </ul>

--- a/lib/exception_notifier/views/exception_notifier/_data.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/_data.text.erb
@@ -1,1 +1,1 @@
-* data: <%= raw PP.pp(@data, "") %>
+* data: <%= raw PP.pp(@data, +"") %>

--- a/lib/exception_notifier/views/exception_notifier/_session.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/_session.html.erb
@@ -5,6 +5,6 @@
   </li>
   <li>
     <strong>data: </strong>
-    <span><%= PP.pp(@request.session.to_hash, "") %></span>
+    <span><%= PP.pp(@request.session.to_hash, +"") %></span>
   </li>
 </ul>

--- a/lib/exception_notifier/views/exception_notifier/_session.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/_session.text.erb
@@ -1,2 +1,2 @@
 * session id: <%= @request.ssl? ? "[FILTERED]" : (raw (@request.session['session_id'] || (@request.env["rack.session.options"] and @request.env["rack.session.options"][:id])).inspect.html_safe) %>
-* data: <%= raw PP.pp(@request.session.to_hash, "") %>
+* data: <%= raw PP.pp(@request.session.to_hash, +"") %>


### PR DESCRIPTION
When `ActionView::Template.frozen_string_literal` is set to true (e.g. via [`Rails.config.action_view.frozen_string_literal`](https://guides.rubyonrails.org/configuring.html#config-action-view-frozen-string-literal)), we get errors while rendering exception_notifier templates inside PP.pp on Ruby 3.3.6:

```
   ActionView::Template::Error: can't modify frozen String: ""

  /app/vendor/ruby-3.3.6/lib/ruby/3.3.0/prettyprint.rb:184:in `text'
  /app/vendor/ruby-3.3.6/lib/ruby/3.3.0/prettyprint.rb:252:in `group'
  /app/vendor/ruby-3.3.6/lib/ruby/3.3.0/pp.rb:201:in `pp'
  /app/vendor/ruby-3.3.6/lib/ruby/3.3.0/pp.rb:97:in `block in pp'
  /app/vendor/ruby-3.3.6/lib/ruby/3.3.0/pp.rb:158:in `guard_inspect_key'
  /app/vendor/ruby-3.3.6/lib/ruby/3.3.0/pp.rb:97:in `pp'
  /app/vendor/bundle/ruby/3.3.0/gems/exception_notification-4.5.0/lib/exception_notifier/views/exception_notifier/_session.text.erb:2:in `_vendor_bundle_ruby_______gems_exception_notification_______lib_exception_notifier_views_exception_notifier__session_text_erb__2544461215938986440_61040'
```

The emails still come through, but the session data is replaced with this exception instead. I've seen other libraries avoid this for strings that need to be mutable by replacing `""` with `+""`, to ensure it's a copy of the literal and therefore mutable.

I'm not entirely sure this entirely solves the problem - I wasn't able to properly run the exception_notification tests locally, and haven't managed to test this in my application yet - but it should help out!

I understand [Ruby 3.4 will make this configuration the default](https://www.ruby-lang.org/en/news/2024/05/16/ruby-3-4-0-preview1-released/), so this may become more pressing shortly.