### PR TITLE
Redirect gh-pages to new fork

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <script>window.location.href = "https://github.com/kmcphillips/exception_notification"</script>
     <script src="documentup.min.js"></script>
     <script>
       DocumentUp.document({


### PR DESCRIPTION
The link in the repo "description" could also be changed/removed:

![Screenshot 2025-04-04 at 08 51 16](https://github.com/user-attachments/assets/3de17faa-7a52-4038-9e59-213de51538f0)
